### PR TITLE
Overhaul of nearstars.stc

### DIFF
--- a/data/nearstars.stc
+++ b/data/nearstars.stc
@@ -1,22 +1,24 @@
 # Nearby stars and star orbits out to 25 light years, supplementary
 # to Celestia's stars.dat.
 
-# Data are mainly derived from the RECONS survey tabulation at
-# http://www.chara.gsu.edu/RECONS/TOP100.posted.htm. In particular, the 
-# distances given are derived from RECONS's weighted average parallaxes,
-# rather than pure Hipparcos data. Additional definitions are provided
-# for some stars within 25 light years which are beyond the limit of RECONS
-# tabulation: these are non-Hipparcos stars, multiple stars, and stars
-# with other known properties not present in stars.dat.
+# Because the RECONS survey tabulation has not been updated since 2010,
+# the data mostly comes from the SIMBAD database, with most parallaxes
+# coming from Gaia DR2. Gaia DR2 does not provide parallaxes for the brightest
+# stars, so for those the Hipparcos parallaxes have been used. In some cases
+# where Gaia DR2 parallaxes exist for one of the component stars, that has been
+# used; if two or more components have them, the average of the derived distances
+# have been used.
 
-# Orbits are taken from Staffan Söderhjelm's "Visual binary orbits and
-# masses post Hipparcos" A&A 1999; 34: 121-40
-# (http://adsabs.harvard.edu/abs/1999A&A...341..121S), unless newer data
-# have been found. If orbits don't appear in Söderhjelm, they have been
-# taken from the Sixth Catalog of Orbits of Visual Binary Stars
-# (http://ad.usno.navy.mil/wds/orb6.html) and the Ninth Catalogue of
-# Spectroscopic Binary Orbits (http://sb9.astro.ulb.ac.be). Other sources
-# appear as comments for individual star systems.
+# Most brown dwarfs in this file do not have Gaia parallaxes, in which case the
+# parallax comes from Martin et al. (2018), ApJ 867 (2), 109
+# "Y Dwarf Trigonometric Parallaxes from the Spitzer Space Telescope"
+# https://arxiv.org/abs/1809.06479
+# Other sources are appear as comments for individual star 
+# systems.
+
+# Orbits are taken from the Sixth Catalog of Orbits of Visual Binary Stars
+# (http://ad.usno.navy.mil/wds/orb6.html), with other sources in the comments
+# below.
 
 # For binary orbits, the direction of an orbit's node on the plane of the 
 # sky is often unknown - the orbits given below will appear correct when
@@ -24,17 +26,8 @@
 # or away from the Earth.
 # For a few orbits the nature of the node is known - these are
 # marked with the phrase "fully specified orientation".
-# Barycenter positions are based on mass estimates from Söderhjelm or RECONS:
-# the figures used are added as comments below.
-
-# Celestia's estimate of star radius is poor for cool stars. Many
-# radii are corrected by the measured data in charm2.stc. To avoid
-# the appearance of unphysically small red dwarf stars in this file,
-# approximate radii for spectral type have been added for nearby 
-# red dwarfs not covered by Charm2. Data are taken from Table 1 in 
-# Kaltenegger and Traub (2009) Transits of Earth-like planets. 
-# ApJ 698:519-27.
-# (iopscience.iop.org/0004-637X/698/1/519/pdf/0004-637X_698_1_519.pdf)
+# Barycenter positions are based on mass estimates from the papers themselves,
+# or if lacking, RECONS. The values used are listed below.
 
 Barycenter "Solar System Barycenter:SSB"
 {
@@ -50,38 +43,32 @@ Barycenter "Solar System Barycenter:SSB"
 
 	SpectralType "G2V"
 	AbsMag 4.83
-	Temperature 5780
-	BoloCorrection -0.08
-	
+
 	UniformRotation
 	{
-	    Period         609.12  # 25.38 days
-	    Inclination      7.25
-	    AscendingNode   75.77
-	    MeridianAngle   23.00  # standard meridian
+		Period       609.12 # 25.38 days
+		Inclination    7.25
+		AscendingNode 75.77
+		MeridianAngle 23.00 # standard meridian
 	}
 }
 
 70890 # Proxima Cen
 {
-	RA 217.429167
-	Dec -62.679444
-	Distance 4.242
-	SpectralType "M5.0V"
-	AppMag 11.05
+	RA  217.42893801
+	Dec -62.67949189
+	Distance 4.2441 # 768.5004 +/- 0.2030 mas
+	SpectralType "M5.5Ve"
+	AppMag 11.09
 }
 
-Barycenter "Rigil Kentaurus:Toliman:ALF Cen:Gliese 559"
+# Distance from the same source as orbits
+Barycenter "Rigel Kentaurus:Toliman:ALF Cen:Gliese 559"
 {
-	RA  219.900833
-	Dec -60.835556
-	Distance 4.365
+	RA  219.8993053 # mass ratio 1.133:0.972
+	Dec -60.8356249
+	Distance 4.3897 # 743 +/- 1.3 mas
 }
-
-# Pourbaix et al. (2002) Constraining the difference in 
-# convective blueshift between the components of alpha Centauri 
-# with precise radial velocities
-# http://www.aanda.org/index.php?option=com_article&access=bibcode&Itemid=129&bibcode=2002A%2526A...386..280PFUL
 
 71683 # ALF Cen A
 {
@@ -89,103 +76,140 @@ Barycenter "Rigil Kentaurus:Toliman:ALF Cen:Gliese 559"
 	SpectralType "G2V"
 	AppMag 0.01
  
-	EllipticalOrbit {		# fully specified orientation
+	EllipticalOrbit {              # fully specified orientation
 		Period           79.91
-		SemiMajorAxis    10.77 # mass ratio 1.105:0.934
-		Eccentricity      0.5179
-		Inclination      82.45
-		AscendingNode   231.72
-		ArgOfPericenter 279.60
-		MeanAnomaly     200.16
+		SemiMajorAxis    10.68 # mass ratio 1.133:0.972
+		Eccentricity      0.52
+		Inclination      82.98
+		AscendingNode    67.55
+		ArgOfPericenter   4.42
+		MeanAnomaly     199.75
 	}			 
 }
 
-71681 # ALF cen B
+71681 # ALF Cen B
 {
 	OrbitBarycenter "ALF Cen"
-	SpectralType "K0V"
-	AppMag 1.34
+	SpectralType "K1V"
+	AppMag 1.33
 
-	EllipticalOrbit {		# fully specified orientation   
+	EllipticalOrbit {              # fully specified orientation
 		Period           79.91
-		SemiMajorAxis    12.75 # mass ratio 1.105:0.934
-		Eccentricity      0.5179
-		Inclination      82.45
-		AscendingNode   231.72
-		ArgOfPericenter  99.60
-		MeanAnomaly     200.16
-	}			 
+		SemiMajorAxis    12.79 # mass ratio 1.133:0.972
+		Eccentricity      0.52
+		Inclination      82.98
+		AscendingNode    67.55
+		ArgOfPericenter 184.42
+		MeanAnomaly     199.75
+	}
 }
 
 87937 # Barnard's Star
 {
-	RA 269.452083
-	Dec 4.693333
-	Distance 5.979
-	SpectralType "M3.5V"
-	AppMag 9.57
+	RA 269.45208250
+	Dec 4.69336427
+	Distance 5.9577 # 547.4506 +/- 0.2899 mas
+	SpectralType "M4V"
+	AppMag 9.511
 }
 
-# KL Luhman. Discovery of a Binary Brown Dwarf at 2 Parsecs from 
-# the Sun. ApJ letters in press. http://arxiv.org/abs/1303.2401
-"WISE 1049-5319 A:WISE J104915.57-531906.1 A"
+# Lazorenko & Sahlmann (2018), A&A 618, A111
+# "Updated astrometry and masses of the LUH 16 brown dwarf binary"
+# https://arxiv.org/abs/1808.07835
+Barycenter "Luhman 16:WISE 1049-5319:WISE J104915.57-531906.1"
 {
-	RA 162.315000
-	Dec -53.318333
-	Distance 6.58
-	SpectralType "L8"
-	AbsMag 23 # for approximate radius in Celestia 
+	RA 162.328812
+	Dec -53.319467
+	Distance 6.5029 # 501.557 +/- 0.082 mas
 }
 
-"WISE 1049-5319 B:WISE J104915.57-531906.1 B"
+"Luhman 16 A:WISE 1049-5319 A:WISE J104915.57-531906.1 A"
 {
-	RA 162.315700 # separation 1.5"
-	Dec -53.318333
-	Distance 6.58
-	SpectralType "L9" # "L/T junction"
-	AbsMag 24 # for approximate radius in Celestia 
+	OrbitBarycenter "Luhman 16"
+	SpectralType "L7.5"
+	AbsMag 23 # for approximate radius in Celestia
+
+	EllipticalOrbit {              # fully specified orientation
+		Period           27.54
+		SemiMajorAxis     1.64 # mass ratio 33.51:28.55J
+		Eccentricity      0.34
+		Inclination      64.67
+		AscendingNode   295.52
+		ArgOfPericenter 121.83
+                MeanAnomaly     127.58
+	}
 }
 
+"Luhman 16 B:WISE 1049-5319 B:WISE J104915.57-531906.1 B"
+{
+	OrbitBarycenter "Luhman 16"
+	SpectralType "T0.5"
+	AbsMag 24 # for approximate radius in Celestia
+
+	EllipticalOrbit {              # fully specified orientation
+		Period           27.54
+		SemiMajorAxis     1.92 # mass ratio 33.51:28.55J
+		Eccentricity      0.34
+		Inclination      64.67
+		AscendingNode   295.52
+		ArgOfPericenter 301.83
+                MeanAnomaly     127.58
+	}
+}
+
+"WISE 0855âˆ’0714:WISE J085510.83-071442.5"
+{
+	RA 133.795125
+	Dec -7.2451389
+	Distance 7.264 # 449 +/- 8 mas
+	SpectralType "T9"
+	AbsMag 38 # for approximate radius in Celestia
+}
+
+# Parallax from Weinberger, et al. (2016), AJ 152 (1), 24
+# "Trigonometric Parallaxes and Proper Motions of 134 Southern Late M, L, 
+# and T Dwarfs from the Carnegie Astrometric Planet Search Program"
+# http://iopscience.iop.org/article/10.3847/0004-6256/152/1/24
 "CN Leo:Gliese 406:Wolf 359"
 {
-	RA 164.121783
-	Dec 7.014722
-	Distance 7.782
-	SpectralType "M5.5V"
-	Radius 122000 # approx. for class
-	AppMag 13.53
+	RA 164.1201092
+	Dec 7.014540
+	Distance 7.8948 # 413.13 +/- 1.27 mas
+	SpectralType "M6V"
+	AppMag 13.507
 }
 
 54035 # Lalande 21185
 {
-	RA 165.834167
-	Dec 35.970000
-	Distance 8.294
-	SpectralType "M2.0V"
-	AppMag 7.47
+	RA 165.83414166
+	Dec 35.96988004
+	Distance 8.3067 # 392.64 +/- 0.67 mas
+	SpectralType "M2V"
+	AppMag 7.520
 }
 
+# Distance from same source as orbits
 Barycenter 32349 "Sirius:Alhabor:ALF CMa:9 CMa:Gliese 244:ADS 5423"
 {
-	RA 101.287083
-	Dec -16.716111
-	Distance 8.583
+	RA 101.28715533
+	Dec -16.71611586
+	Distance 8.608 # 378.9 +/- 1.4 mas
 }
 
 "Sirius A:Alhabor A:ALF CMa A:9 CMa A:Gliese 244 A:ADS 5423 A"
 {
 	OrbitBarycenter "Sirius"
 	SpectralType "A1V"
-	AppMag -1.43
+	AppMag -1.46
 
 	EllipticalOrbit {              # fully specified orientation
-		Period          50.09
-		SemiMajorAxis   6.73   # mass ratio 1.99:1.03
-		Eccentricity    0.5923
-		Inclination	97.51
-		AscendingNode   161.33
-		ArgOfPericenter 4.56
-		MeanAnomaly     40.89
+		Period           50.13
+		SemiMajorAxis     9.13 # mass ratio 2.063:1.018
+		Eccentricity      0.59
+		Inclination      97.01
+		AscendingNode   161.67
+		ArgOfPericenter   5.90
+		MeanAnomaly      38.99
 	}
 }
 
@@ -196,174 +220,163 @@ Barycenter 32349 "Sirius:Alhabor:ALF CMa:9 CMa:Gliese 244:ADS 5423"
 	AppMag 8.44
 
 	EllipticalOrbit {              # fully specified orientation
-		Period          50.09
-		SemiMajorAxis   13.00  # mass ratio 1.99:1.03
-		Eccentricity    0.592
-		Inclination	97.51
-		AscendingNode   161.33
-		ArgOfPericenter 184.56
-		MeanAnomaly     40.89
+		Period           50.09
+		SemiMajorAxis    10.65 # mass ratio 2.063:1.018
+		Eccentricity      0.59
+		Inclination      97.01
+		AscendingNode   161.67
+		ArgOfPericenter 185.90
+		MeanAnomaly      38.99
 	}
 }
 
+# Distance and radii from same source as orbit
+# Rotation periods from Barnes et al. (2017), MNRAS 471 (1), 811
+# "Surprisingly different star-spot distributions on the near equal-mass 
+# equal-rotation-rate stars in the M dwarf binary GJ 65 AB"
+# https://arxiv.org/abs/1706.03979
 Barycenter "Gliese 65:Luyten 726-8"
 {
-	RA 24.755529
-	Dec -17.950278
-	Distance 8.728
+	RA 24.75626394 # mass ratio 0.1225:0.1195
+	Dec -17.950491
+	Distance 8.791 # 373.70 +/- 2.70 mas
 }
 
 "BL Cet:Gliese 65 A:Luyten 726-8 A"
 {
-	OrbitBarycenter "Gliese 65"
+ 	OrbitBarycenter "Gliese 65"
 	SpectralType "M5.5V"
-	Radius 122000 # approx. for class
-	AppMag 12.61
+	AppMag 12.7
+	Radius 114790
 
 	EllipticalOrbit {
-		Period          26.52
-		SemiMajorAxis   2.61    # mass ratio 0.1:0.1
-		Eccentricity    0.62
-		Inclination	101.3
-		AscendingNode   159.5
-		ArgOfPericenter 39.7
-		MeanAnomaly     21.3
+	 	Period           26.28
+	 	SemiMajorAxis     2.72 # mass ratio 0.1225:0.1195
+	 	Eccentricity      0.62
+	 	Inclination      91.85
+		AscendingNode   157.40
+		ArgOfPericenter  40.22
+		MeanAnomaly      21.93
 	}
+
+	RotationPeriod 5.76
 }
 
 "UV Cet:Gliese 65 B:Luyten 726-8 B"
 {
 	OrbitBarycenter "Gliese 65"
-	SpectralType "M6.0V"
-	Radius 105000 # approx. for class
-	AppMag 13.06
+	SpectralType "M6V"
+	AppMag 13.2
+	Radius 110600
 
 	EllipticalOrbit {
-		Period          26.52
-		SemiMajorAxis   2.61   # mass ratio 0.1:0.1
-		Eccentricity    0.62
-		Inclination	101.3
-		AscendingNode   159.5
-		ArgOfPericenter 219.7
-		MeanAnomaly     21.3
+		Period           26.28
+		SemiMajorAxis     2.79 # mass ratio 0.1225:0.1195
+		Eccentricity      0.62
+	 	Inclination      91.85
+		AscendingNode   157.40
+		ArgOfPericenter 220.22
+		MeanAnomaly      21.93
 	}
-}
 
-# Kirpatrick et al. (2011) The First Hundred Brown Dwarfs 
-# Discovered by the Wide-field Infrared Survey Explorer (WISE)
-# http://arxiv.org/abs/1108.4677
-"WISE 1541-2250:WISE J1541-2250:WISEPA J154151.66-225025.2"
-{
-	Texture "exo-class4night.*"
-	RA 235.465417
-	Dec -22.840278
-	Distance 9.3
-	SpectralType "T9.5" # actually Y0
-	Temperature 350
-	Radius 70000
-	AbsMag 50 # extremely low
+	RotationPeriod 5.52
 }
 
 92403 # Ross 154
 {
-	RA 282.455833
-	Dec -23.836111
-	Distance 9.672
-	SpectralType "M3.5V"
-	Radius 225000 # approx. for class
-	AppMag 10.44
+	RA 282.45568250
+	Dec -23.83623710
+	Distance 9.7035 # 336.1228 +/- 0.0641 mas
+	SpectralType "M3.5Ve"
+	AppMag 10.495
 }
 
 "HH And:Gliese 905:Ross 248"
 {
-	RA 355.479875
-	Dec 44.177222
-	Distance 10.310
-	SpectralType "M5.5V"
-	Radius 122000 # approx. for class
-	AppMag 12.29
+	RA 355.47931716
+	Dec 44.17745144
+	Distance 10.2903 # 316.9558 +/- 0.1260 mas
+	SpectralType "M5.0V"
+	AppMag 12.28
 }
 
 16537 # Eps Eri
 {
-	RA 53.232500
-	Dec -9.458333
-	Distance 10.480
+	RA 53.23268735
+	Dec -9.45825866
+	Distance 10.489 # 310.94 +/- 0.16 mas
 	SpectralType "K2V"
 	AppMag 3.73
 }
 
 114046 # Lacaille 9352
 {
-	RA 346.466667
-	Dec -35.853056
-	Distance 10.691
-	SpectralType "M1.0V"
+	RA 346.46681439
+	Dec -35.85307188
+	Distance 10.7211 # 304.2190 +/- 0.0451 mas
+	SpectralType "M2V"
 	AppMag 7.34
 }
 
 57548 # Ross 128
 {
-	RA 176.935000
-	Dec 0.804444
-	Distance 10.940
-	SpectralType "M4.0V"
-	Radius 180000 # approx. for class
-	AppMag 11.16
+	RA 176.93498695
+	Dec 0.80455693
+	Distance 11.0074 # 296.3073 +/- 0.0699 mas
+	SpectralType "M4V"
+	AppMag 11.153
 }
 
-# Delfosse, X. et al. (1999) "New Neighbours I: 13 new
-# companions to nearby M dwarfs" A&A, 344, 897
-# (http://arxiv.org/abs/astro-ph/9812008)
+# Segransan. et al. (2000), A&A 364, 665
+# "Accurate masses of very low mass stars. III. 16 new or improved masses"
+# http://adsabs.harvard.edu/abs/2000A%26A...364..665S
 Barycenter "Gliese 866:Luyten 789-6"
 {
-	RA 339.640833
-	Dec -15.300806
-	Distance 11.266
+	RA 339.6399000
+	Dec -15.2999325
+	Distance 11.109 # 293.6 +/- 0.9 mas
 }
 
 Barycenter "Gliese 866 A:Luyten 789-6 A"
 {
 	OrbitBarycenter "Gliese 866"
 
-	EllipticalOrbit {
-		Period          2.2506
-		SemiMajorAxis   0.42   # mass ratio 0.106:(0.105+0.095)
-		Eccentricity    0.437
-		Inclination	96.2
-		AscendingNode   133.5
-		ArgOfPericenter 76.4
-		MeanAnomaly     241.7
+	EllipticalOrbit {               # fully specified orientation
+		Period            2.2537
+		SemiMajorAxis     0.415 # mass ratio (0.1187:0.0930):0.1145
+		Eccentricity      0.439
+		Inclination	 89.43
+		AscendingNode   358.27
+		ArgOfPericenter  61.70
+		MeanAnomaly     243.55
 	}
 }
 
 "EZ Aqr:Gliese 866 Aa:Luyten 789-6 Aa"
 {
 	OrbitBarycenter "Gliese 866 A"
-	SpectralType "M5.0V"
-	Radius 140000 # approx. for class
+	SpectralType "M5V"
 	AppMag 13.03
 
 	EllipticalOrbit {
-		Period          0.010	# 3.8dys
-		SemiMajorAxis   0.013	# to match period and mass ratio 0.105:0.095
-		Inclination	96	# guess - to match plane of B
-		AscendingNode   133	# guess - to match plane of B
+		Period          0.01037 # 3.786516 d
+		SemiMajorAxis   0.01244 # to match period and mass ratio 0.1187:0.0930
+		Inclination	 90     # plane-of-sky inclination 116.5 deg
+		AscendingNode     2     # guess - to roughly match plane of B
 	}
 }
 
 "Gliese 866 Ab:Luyten 789-6 Ab"
 {
 	OrbitBarycenter "Gliese 866 A"
-	SpectralType "M6V" # from apparent magnitude
-	Radius 105000 # approx. for estimated class
+	SpectralType "M7V" # from mass
 	AppMag 15.07
 
 	EllipticalOrbit {
-		Period          0.010	# 3.8dys
-		SemiMajorAxis   0.014	# to match period and mass ratio 0.105:0.095
-		Inclination	96	# guess - to match plane of B
-		AscendingNode   133	# guess - to match plane of B
+		Period          0.01037 # 3.786516 d
+		SemiMajorAxis   0.01589 # to match period and mass ratio 0.1187:0.0930
+		Inclination	 90     # guess - to match plane of B
+		AscendingNode     2     # guess - to match plane of B
 		ArgOfPericenter 180
 	}
 }
@@ -371,42 +384,46 @@ Barycenter "Gliese 866 A:Luyten 789-6 A"
 "Gliese 866 B:Luyten 789-6 B"
 {
 	OrbitBarycenter "Gliese 866"
-	SpectralType "M5V" # from apparent magnitude
-	Radius 140000 # approx. for estimated class
+	SpectralType "M6V" # from apparent magnitude
 	AppMag 13.27
 
-	EllipticalOrbit {
-		Period          2.2506
-		SemiMajorAxis   0.78   # mass ratio 0.106:(0.105+0.095)
-		Eccentricity    0.437
-		Inclination	96.2
-		AscendingNode   133.5
-		ArgOfPericenter 256.4
-		MeanAnomaly     241.7
+	EllipticalOrbit {               # fully specified orientation
+		Period            2.2537
+		SemiMajorAxis     0.768 # mass ratio (0.1187:0.0930):0.1145
+		Eccentricity      0.439
+		Inclination	 89.43
+		AscendingNode   358.27
+		ArgOfPericenter 241.70
+		MeanAnomaly     243.55
 	}
 }
 
+# physical parameters from Kervella et al. (2008), A&A 488 (2), 667
+# "The radii of the nearby K5V and K7V stars 61 Cygni A & B. CHARA/FLUOR 
+# interferometry and CESAM2k modeling"
+# https://arxiv.org/abs/0806.4049
 Barycenter "61 Cyg:Gliese 820:ADS 14636"
 {
-	RA 316.714507   # mass ratio 0.7:0.63
-	Dec 38.738139   #
-	Distance 11.401
+	RA 316.7273265  # mass ratio 0.690:0.605
+	Dec 38.7459723
+	Distance 11.402
 }
 
 104214 "61 Cyg A:V1803 Cyg:Gliese 820 A:ADS 14636 A"
 {
 	OrbitBarycenter "61 Cyg"
 	SpectralType "K5V"
-	AppMag 5.20
+	AppMag 5.21
+	Radius 462600
 
 	EllipticalOrbit {
-		Period          659
-		SemiMajorAxis   40.40 # mass ratio 0.7:0.63
-		Eccentricity	0.48
-		Inclination	132
-		AscendingNode   165
-		ArgOfPericenter 195
-		MeanAnomaly     165
+		Period          678
+		SemiMajorAxis   39.64 # mass ratio 0.690:0.605
+		Eccentricity    0.49
+		Inclination     135
+		AscendingNode   166
+		ArgOfPericenter 200
+		MeanAnomaly     154
 	}
 }
 
@@ -415,23 +432,25 @@ Barycenter "61 Cyg:Gliese 820:ADS 14636"
 	OrbitBarycenter "61 Cyg"
 	SpectralType "K7V"
 	AppMag 6.03
+	Radius 413900
 
 	EllipticalOrbit {
-		Period          659
-		SemiMajorAxis   44.90 # mass ratio 0.7:0.63
-		Eccentricity	0.48
-		Inclination	132
-		AscendingNode   165
-		ArgOfPericenter 15
-		MeanAnomaly     165
+		Period         678
+		SemiMajorAxis  45.21 # mass ratio 0.690:0.605
+		Eccentricity   0.49
+		Inclination    135
+		AscendingNode  167
+		ArgOfPericenter 20
+		MeanAnomaly    155
 	}
 }
 
+# Distance from same source as orbit
 Barycenter 37279 "Procyon:Elgomaisa:ALF CMi:10 CMi:Gliese 280:ADS 6251"
 {
-	RA 114.82724
-	Dec 5.2275076
-	Distance 11.438
+	RA 114.82549791
+	Dec 5.22498756
+	Distance 11.444 # 250.0 +/- 0.7 mas
 }
 
 "Procyon A:Elgomaisa A:ALF CMi A:10 CMi A:Gliese 280 A:ADS 6251 A"
@@ -440,53 +459,56 @@ Barycenter 37279 "Procyon:Elgomaisa:ALF CMi:10 CMi:Gliese 280:ADS 6251"
 	SpectralType "F5IV"
 	AppMag 0.37
 
-	EllipticalOrbit {
-		Period          40.82
-		SemiMajorAxis   4.13   # mass ratio 1.57:0.6
-		Eccentricity    0.407
-		Inclination	42.9
-		AscendingNode   27.8
-		ArgOfPericenter 88.4
-		MeanAnomaly     282.5
+	EllipticalOrbit {             # fully specified orientation
+		Period          40.84
+		SemiMajorAxis    4.32 # mass ratio 1.478:0.592
+		Eccentricity     0.40
+		Inclination     42.58
+		AscendingNode   25.26
+		ArgOfPericenter 90.19
+		MeanAnomaly    281.41
 	}
 }
 
-"Procyon B:Elgomaisa B:ALF CMi B:10 CMi B:Gliese 280 B:ADS 6251 B"
+"Procyon B:ALF CMi B:10 CMi B"
 {
 	OrbitBarycenter "Procyon"
 	SpectralType "DA"
-	AppMag 10.70
+	AppMag 10.7
 
-	EllipticalOrbit {
-		Period          40.82
-		SemiMajorAxis   10.80  # mass ratio 1.57:0.6
-		Eccentricity    0.407
-		Inclination	42.9
-		AscendingNode   27.8
-		ArgOfPericenter 268.4
-		MeanAnomaly     282.5
+	EllipticalOrbit {              # fully specified orientation
+		Period           40.84
+		SemiMajorAxis    10.79 # mass ratio 1.478:0.592
+		Eccentricity      0.40
+		Inclination      42.58
+		AscendingNode    25.26
+		ArgOfPericenter 270.19
+		MeanAnomaly     281.41
 	}
 }
 
+# masses from Mann et al. (2015), ApJ 804 (1), 64
+# "How to Constrain Your M Dwarf: Measuring Effective Temperature, 
+# Bolometric Luminosity, Mass, and Radius"
+# http://iopscience.iop.org/article/10.1088/0004-637X/804/1/64/meta
 Barycenter "Gliese 725:ADS 11632:Struve 2398"
 {
-	RA 280.701371   # mass ratio 0.35:0.26
-	Dec 59.624455   #
-	Distance 11.492
+	RA 280.6949398  # mass ratio 0.334:0.248
+	Dec 59.6288903
+	Distance 11.488
 }
 
 91768 "Gliese 725 A:ADS 11632 A:Struve 2398 A"
 {
-	OrbitBarycenter "Gliese 725"
-	SpectralType "M3.0V"
-	Radius 270000 # approx. for class
-	AppMag 8.90
+	OrbitBarycenter "ADS 11632"
+	SpectralType "M3V"
+	AppMag 8.91
 
 	EllipticalOrbit {
-		Period          408
-		SemiMajorAxis   20.91 # mass ratio 0.35:0.26
-		Eccentricity	0.53
-		Inclination	112
+		Period            408
+		SemiMajorAxis   20.83 # mass ratio 0.334:0.248
+		Eccentricity     0.53
+		Inclination     111.9
 		AscendingNode   146.1
 		ArgOfPericenter 243.5
 		MeanAnomaly     198.5
@@ -495,42 +517,47 @@ Barycenter "Gliese 725:ADS 11632:Struve 2398"
 
 91772 "Gliese 725 B:ADS 11632 B:Struve 2398 B"
 {
-	OrbitBarycenter "Gliese 725"
+	OrbitBarycenter "ADS 11632"
 	SpectralType "M3.5V"
-	Radius 225000 # approx. for class
 	AppMag 9.69
 
 	EllipticalOrbit {
-		Period          408
-		SemiMajorAxis   28.14 # mass ratio 0.35:0.26
-		Eccentricity	0.53
-		Inclination	112
-		AscendingNode   146.1
+		Period           408
+		SemiMajorAxis  28.06 # mass ratio 0.334:0.248
+		Eccentricity    0.53
+		Inclination    111.9
+		AscendingNode  146.1
 		ArgOfPericenter 63.5
-		MeanAnomaly     198.5
+		MeanAnomaly    198.5
 	}
 }
 
+# Pinamonti et al. (2018), A&A 617, A104
+# "The HADES RV Programme with HARPS-N at TNG. VIII. GJ15A: a multiple
+# wide planetary system sculpted by binary interaction"
+# https://arxiv.org/abs/1804.03476
 Barycenter 1475 "Gliese 15:ADS 246:Groombridge 34"
 {
-	RA 4.595417
-	Dec 44.023056
-	Distance 11.654
+	RA 4.600573040  # mass ratio 0.38:0.15
+	Dec 44.02478402
+	Distance 11.619
 }
 
 "GX And:Gliese 15 A:ADS 246 A:Groombridge 34 A"
 {
 	OrbitBarycenter "Groombridge 34"
-	SpectralType "M1.5V"
-	AppMag 8.08
+	SpectralType "M2V"
+	AppMag 8.13
+	Radius 264400
 
 	EllipticalOrbit {
-		Period          2600
-		SemiMajorAxis   36.1   # mass ratio 0.49:0.16
-		Eccentricity	0
-		Inclination	67.9
-		AscendingNode   308.4
-		MeanLongitude   23.0
+		Period         1230
+		SemiMajorAxis 26.32 # mass ratio 0.38:0.15
+		Eccentricity   0.53
+		Inclination     172
+		AscendingNode   194
+		ArgOfPericenter  75
+		MeanAnomaly     296
 	}
 }
 
@@ -538,55 +565,70 @@ Barycenter 1475 "Gliese 15:ADS 246:Groombridge 34"
 {
 	OrbitBarycenter "Groombridge 34"
 	SpectralType "M3.5V"
-	Radius 225000 # approx. for class
-	AppMag 11.06
+	AppMag 11.04
+	Radius 125200
 
 	EllipticalOrbit {
-		Period          2600
-		SemiMajorAxis   110.7  # mass ratio 0.49:0.16
-		Eccentricity	0
-		Inclination	67.9
-		AscendingNode   308.4
-		MeanLongitude   203.0
+		Period         1230
+		SemiMajorAxis 66.68 # mass ratio 0.38:0.15
+		Eccentricity   0.53
+		Inclination     172
+		AscendingNode   194
+		ArgOfPericenter 255
+		MeanAnomaly     296
 	}
+}
+
+"DX Cnc:Gliese 1111:Giclas 51-15"
+{
+	RA 127.45563677
+	Dec 26.77600744
+	Distance 11.6780 # 279.2901 +/- 0.1345 mas
+	SpectralType "M6.5V"
+	AppMag 14.81
 }
 
 Barycenter "EPS Ind:Gliese 845" # orbit of A & B components unknown
 {
-	RA 330.841091   # mass ratio 0.77:(0.04+0.03)
-	Dec -56.780045
-	Distance 11.815
+	RA 330.87262069 # mass ratio 0.732:(0.0716:0.0669)
+	Dec -56.7854593
+	Distance 11.870
 }
 
 108870 "EPS Ind A:Gliese 845 A"
 {
-	RA 330.82266
-	Dec -56.779804
-	Distance 11.815
-	SpectralType "K4V"
-	AppMag 4.68
+	RA 330.84022596
+	Dec -56.7859825
+	Distance 11.8686 # 274.8048 +/- 0.2494 mas
+	SpectralType "K5V"
+	AppMag 4.69
 }
 
-# McCaughrean, M.J. et al.(2004) "Eps Indi Ba,Bb: The nearest binary
-# brown dwarf" A&A 413, 1029.
-# (http://arxiv.org/PS_cache/astro-ph/pdf/0309/0309256.pdf)
+# Dieterich et al. (2017) "Dynamical Masses of Îµ Indi B and C: Two Massive
+# Brown Dwarfs at the Edge of the Stellarâ€“substellar Boundary"
+# https://arxiv.org/abs/1807.09880
 Barycenter "EPS Ind B:CI Ind:Gliese 845 B"
 {
-	RA 331.043833
+	RA 331.0438333
 	Dec -56.782694
-	Distance 11.815
+	Distance 11.780 # 276.88 +/- 0.81 mas
 }
 
 "EPS Ind Ba:CI Ind A:Gliese 845 Ba"
 {
 	OrbitBarycenter "EPS Ind B"
-	SpectralType "T1V"
+	SpectralType "T1.5V"
 	Temperature 1280
-	AbsMag 34.9 # for correct radius in Celestia
+	AbsMag 26 # for correct radius in Celestia
 
-	EllipticalOrbit {
-		Period 		15.5 # approximate orbit
-		SemiMajorAxis	0.99 # mass ratio 47:28J
+	EllipticalOrbit {             # fully specified orientation
+		Period          11.41
+		SemiMajorAxis    1.26 # mass ratio 75.0:70.1J
+		Eccentricity     0.47
+		Inclination     77.95
+		AscendingNode  138.03
+		ArgOfPericenter 87.11
+		MeanAnomaly     49.82
 	}
 }
 
@@ -595,207 +637,194 @@ Barycenter "EPS Ind B:CI Ind:Gliese 845 B"
 	OrbitBarycenter "EPS Ind B"
 	SpectralType "T6V"
 	Temperature 850
-	AbsMag 51.4 # for correct radius in Celestia
+	AbsMag 33.5 # for correct radius in Celestia
 
-	EllipticalOrbit {
-		Period 		15.5 # approximate orbit
-		SemiMajorAxis	1.66 # mass ratio 47:28J
-		ArgOfPericenter 180
+	EllipticalOrbit {              # fully specified orientation
+		Period           11.41
+		SemiMajorAxis     1.35 # mass ratio 75.0:70.1J
+		Eccentricity      0.47
+		Inclination      77.95
+		AscendingNode   138.03
+		ArgOfPericenter 267.11
+		MeanAnomaly      49.82
 	}
-}
-
-"DX Cnc:GJ 1111:Giclas 51-15"
-{
-	RA 127.456125
-	Dec 26.775611
-	Distance 11.826
-	SpectralType "M6.0V"
-	Radius 105000 # approx. for class
-	AppMag 14.90
 }
 
 8102 # Tau Cet
 {
-	RA 26.017083
-	Dec -15.937500
-	Distance 11.905
-	SpectralType "G8.5V"
-	AppMag 3.49
+	RA 26.01701426
+	Dec -15.93747960
+	Distance 11.905 # 273.96 +/- 0.17 mas
+	SpectralType "G8V"
+	AppMag 3.50
 }
 
-"GJ 1061:Luyten 372-58:RECONS 1"
+"Gliese 1061:Luyten 372-58"
 {
-	RA 53.998750
-	Dec -44.512500
-	Distance 11.991
-	SpectralType "M5.0V"
-	Radius 140000 # approx. for class
-	AppMag 13.09
+	RA 53.99874864
+	Dec -44.51270146
+	Distance 11.9803 # 272.2446 +/- 0.0661 mas
+	SpectralType "M5.5V"
+	AppMag 13.03
 }
 
-5643 # Luyten 725-032
+5643 # YZ Cet
 {
-	RA 18.127500
-	Dec -16.999167
-	Distance 12.121
-	SpectralType "M4.0V"
-	Radius 180000 # approx. for class
-	AppMag 12.10
+	RA 18.12765323
+	Dec -16.99898925
+	Distance 12.1084 # 269.3628 +/- 0.0785 mas
+	SpectralType "M4.0Ve"
+	AppMag 12.074
 }
 
 36208 # Luyten's Star
 {
-	RA 111.852083
-	Dec 5.225833
-	Distance 12.251
+	RA 111.85208229
+	Dec 5.22578699
+	Distance 12.402 # 262.98 +/- 1.39 mas
 	SpectralType "M3.5V"
-	Radius 225000 # approx for class
-	AppMag 9.85
+	AppMag 9.872
 }
 
-# Biller B.A. et al.(2006) "Discovery of the Closest Brown Dwarf to
-# the Sun? A Methane Rich Brown Dwarf Around the Nearby M8.5 Star
-# SCR 1845"
-# (http://xxx.uni-augsburg.de/PS_cache/astro-ph/pdf/0601/0601441.pdf)
-Barycenter "SCR 1845-6357:SCR J1845-6357:2MASS 1845-6357:2MASS J18450541-6357475"
+"Teegarden's Star:SO0253+1652:SO025300.5+165258"
 {
-	RA 281.260833
-	Dec -63.964444
-	Distance 12.569
-}
-
-"SCR 1845-6357 A:SCR J1845-6357 A:2MASS 1845-6357 A:2MASS J18450541-6357475 A"
-{
-	OrbitBarycenter "SCR 1845-6357"
-	SpectralType "M8.5V"
-	Radius 66000 # approx. for class
-	AppMag 17.40
-
-	EllipticalOrbit {
-		Period 		23.5 # estimate
-		SemiMajorAxis	1.6  # estimated mass ratio 0.07:0.045
-		ArgOfPericenter 180
-	}
-}
-
-"SCR 1845-6357 B:SCR J1845-6357 B:2MASS 1845-6357 B:2MASS J18450541-6357475 B"
-{
-	OrbitBarycenter "SCR 1845-6357"
-	SpectralType "T6V"
-	Temperature 950
-	Radius 62500
-	AbsMag 50 # faintest visible in Celestia
-
-	EllipticalOrbit {
-		Period 		23.5 # estimate
-		SemiMajorAxis	2.4  # estimated mass ratio 0.07:0.045
-	}
-}
-
-"Teegarden's Star:2MASS 0253+1652:2MASS J02530084+1652532:SO 0253+1652:SO J025300.5+165258"
-{
-	RA 43.253613
-	Dec 16.881389
-	Distance 12.573
-	SpectralType "M6.5V"
-	Radius 94000 # approx. for class
-	AppMag 15.14
+	RA 43.25371387
+	Dec 16.88128947
+	Distance 12.4957 # 261.0147 +/- 0.2690 mas
+	SpectralType "M7.0V"
+	AppMag 15.40
 }
 
 24186 # Kapteyn's Star
 {
-	RA 77.919167
-	Dec -45.018333
-	Distance 12.757
-	SpectralType "M2.0VI"
-	AppMag 8.85
+	RA 77.91912216
+	Dec -45.01843165
+	Distance 12.8294 # 254.2263 +/- 0.0263 mas
+	SpectralType "M1VI"
+	AppMag 8.853
 }
 
 105090 # Lacaille 8760
 {
-	RA 319.313750
-	Dec -38.867500
-	Distance 12.869
-	SpectralType "K9.0V"
-	AppMag 6.67
+	RA 319.31362024
+	Dec -38.86736390
+	Distance 12.9515 # 251.8295 +/- 0.0559 mas
+	SpectralType "M1V"
+	AppMag 6.68
 }
 
-"DENIS 1048-3956:DENIS-P J104814.9-395604:RECONS 2:2MASS 1048-3956:2MASS J10481463-3956062"
+# used Gaia DR2 parallax for A
+# parameters from Vigan et al. (2012), A&A 540, A131
+# "High-contrast spectroscopy of SCR J1845-6357 B"
+# https://www.aanda.org/articles/aa/abs/2012/04/aa18426-11/aa18426-11.html
+Barycenter "SCR 1845-6357"
 {
-	Texture "browndwarf.*"
-	RA 162.061250
-	Dec -39.935000
-	Distance 13.124
+	RA 281.27187786
+	Dec -63.96318293
+	Distance 13.0505 # 249.9187 +/- 0.1551 mas
+}
+
+"SCR 1845-6357 A"
+{
+	OrbitBarycenter "SCR 1845-6357"
 	SpectralType "M8.5V"
-	Radius 66000 # approx. for class
-	AppMag 17.39
+	AppMag 17.40
+
+	EllipticalOrbit {
+		Period 		24  # estimate
+		SemiMajorAxis	1.6 # estimated mass ratio 0.07:0.045
+		ArgOfPericenter 180
+	}
+}
+
+"SCR 1845-6357 B"
+{
+	OrbitBarycenter "SCR 1845-6357"
+	SpectralType "T6V"
+	AbsMag 33.5 # for approximate radius in Celestia
+
+	EllipticalOrbit {
+		Period 		24  # estimate
+		SemiMajorAxis	2.4 # estimated mass ratio 0.07:0.045
+	}
 }
 
 Barycenter 110893 "Gliese 860:ADS 15972:Kruger 60"
 {
-	RA 336.997917
-	Dec 57.695833
-	Distance 13.149
+	RA 336.9985152  # mass ratio 0.30:0.17
+	Dec 57.69579262 # only used parallax of A
+	Distance 13.0780 # 249.3926 +/- 0.1653 mas
 }
 
 "Gliese 860 A:ADS 15972 A:Kruger 60 A"
 {
 	OrbitBarycenter "Kruger 60"
-	SpectralType "M3.0V"
-	Radius 270000 # approx. for class
-	AppMag 9.79
+	SpectralType "M3V"
+	AppMag 9.93
 
 	EllipticalOrbit {
-		Period           44.64
-		SemiMajorAxis     3.53 # mass ratio 0.30:0.17
+		Period           44.67
+		SemiMajorAxis     3.46 # mass ratio 0.30:0.17
 		Eccentricity      0.41
-		Inclination      34.04
-		AscendingNode   120.09
-		ArgOfPericenter 269.84
-		MeanAnomaly     239.52
+		Inclination      37.04
+		AscendingNode   126.59
+		ArgOfPericenter 264.09
+		MeanAnomaly     240.00
 	}
 }
 
-"DO Cep:Gliese 860 B:ADS 15972 B:Kruger 60 B"
+2000923991 "DO Cep:Gliese 860 B:ADS 15972 B:Kruger 60 B"
 {
 	OrbitBarycenter "Kruger 60"
-	SpectralType "M4.0V"
-	Radius 180000 # approx. for class
+	SpectralType "M4V"
 	AppMag 11.41
 
 	EllipticalOrbit {
-		Period           44.64
-		SemiMajorAxis     6.23 # mass ratio 0.30:0.17
-		Eccentricity      0.41
-		Inclination      34.04
-		AscendingNode   120.09
-		ArgOfPericenter  89.84
-		MeanAnomaly     239.52
+		Period          44.67
+		SemiMajorAxis    6.10 # mass ratio 0.30:0.17
+		Eccentricity     0.41
+		Inclination     37.04
+		AscendingNode  126.59
+		ArgOfPericenter 84.09
+		MeanAnomaly    240.00
 	}
 }
 
+"DENIS 1048-3956:RECONS 2"
+{
+	Texture "browndwarf.*"
+	RA 162.06072261
+	Dec -39.93523423
+	Distance 13.1932 # 247.2157 +/- 0.1236 mas
+	SpectralType "M9V"
+	AppMag 17.532
+}
+
+# masses and parallaxes from Benedict et al. (2016), AJ 152 (5), 141
+# "The Solar Neighborhood. XXXVII: The Mass-Luminosity Relation for Main-sequence
+# M Dwarfs"
+# http://iopscience.iop.org/article/10.3847/0004-6256/152/5/141/meta
 Barycenter 30920 "Gliese 234:Ross 614"
 {
-	RA  97.347500
-	Dec -2.813889
-	Distance 13.343
+	RA 97.34746466
+	Dec -2.81355664
+	Distance 13.4239 # 242.9659 +/- 0.8833 mas
 }
 
 "V577 Mon:Gliese 234 A:Ross 614 A"
 {
 	OrbitBarycenter "Ross 614"
 	SpectralType "M4.5V"
-	Radius 160000 # approx. for class
-	AppMag 11.18
+	AppMag 11.15
 
-	EllipticalOrbit {
-		Period            16.5
-		SemiMajorAxis     1.31 # mass ratio 0.22:0.09
+	EllipticalOrbit {              # fully specified orientation
+		Period           16.63
+		SemiMajorAxis     1.48 # mass ratio 0.223:0.109
 		Eccentricity      0.38
-		Inclination      54.18
-		AscendingNode    71.17
-		ArgOfPericenter 130.67
-		MeanAnomaly       0.00
+		Inclination      93.87
+		AscendingNode   322.71
+		ArgOfPericenter 347.29
+		MeanAnomaly      15.85
 	}
 }
 
@@ -803,535 +832,565 @@ Barycenter 30920 "Gliese 234:Ross 614"
 {
 	OrbitBarycenter "Ross 614"
 	SpectralType "M7V"
-	Radius 83500 # approx. for class
-	AppMag 14.26
+	AppMag 14.23
 
-	EllipticalOrbit {
-		Period            16.5
-		SemiMajorAxis     3.19 # mass ratio 0.22:0.09
+	EllipticalOrbit {              # fully specified orientation
+		Period           16.63
+		SemiMajorAxis     3.02 # mass ratio 0.223:0.109
 		Eccentricity      0.38
-		Inclination      54.18
-		AscendingNode    71.17
-		ArgOfPericenter 310.67
-		MeanAnomaly       0.00
+		Inclination      93.87
+		AscendingNode   322.71
+		ArgOfPericenter 167.29
+		MeanAnomaly      15.85
 	}
 }
 
-# The discovery of a very cool, very nearby brown dwarf 
-# in the Galactic plane. Lucas et al. http://arxiv.org/abs/1004.0317v2
-"UGPS 0722-05:UGPS J0722-05:UGPS J072227.51-054031.2"
+# low-quality parallax from Theissen, C. A. (2018), ApJ 862 (2), 173
+# "Parallaxes of Cool Objects with WISE: Filling in for Gaia"
+# http://iopscience.iop.org/article/10.3847/1538-4357/aaccfa/meta
+"UGPS 0722âˆ’0540:UGPS J072227.51-054031.2"
 {
+	RA 110.6161250
+	Dec -5.6753056
+	Distance 13.433 # 242.8 +/- 2.40 mas
 	Texture "exo-class4night.*"
-	RA 110.613750
-	Dec -5.675000
-	Distance 13.367
-	SpectralType "T9"
-	Temperature 540
-	Radius 70000 # approx.
+	SpectralType "T9V"
+	Temperature 505
+	Radius 75000 # approx.
 	AbsMag 50 # extremely low
 }
 
-80824 # Wolf 1061
-{
-	RA 247.575417
-	Dec -12.662500
-	Distance 13.916
-	SpectralType "M3.5V"
-	Radius 225000 # approx. for class
-	AppMag 10.10
-}
-
-3829 # van Maanen's Star
-{
-	RA 12.291250
-	Dec 5.388611
-	Distance 14.017
-	SpectralType "DZ7"
-	AppMag 12.40
-}
-
-439 # Cordoba 32416
-
-{
-	RA 1.351667
-	Dec -37.357500
-	Distance 14.161
-	SpectralType "M1.5V"
-	Radius 324000 # approx. for class
-	AppMag 8.54
-}
-
+# masses and parallaxes from Benedict et al. (2016), AJ 152 (5), 141
+# "The Solar Neighborhood. XXXVII: The Mass-Luminosity Relation for Main-sequence
+# M Dwarfs"
+# http://iopscience.iop.org/article/10.3847/0004-6256/152/5/141/meta
 Barycenter "Gliese 473:Wolf 424"
 {
-	RA 188.321667
-	Dec 9.020833
-	Distance 14.312
+	RA 188.3223395
+	Dec 9.0210534
+	Distance 13.850 # 235.5 +/- 2.9 mas
 }
 
 "Gliese 473 A:Wolf 424 A"
 {
 	OrbitBarycenter "Wolf 424"
-	SpectralType "M5.0V"
-	Radius 140000 # approx. for class
-	AppMag 13.25
+	SpectralType "M5.5V"
+	AppMag 13.18
 
-	EllipticalOrbit {
-		Period          15.9
-		SemiMajorAxis   1.92 # mass ratio 0.14:0.13
-		Eccentricity	0.3
-		Inclination	28.7
-		AscendingNode   359.5
-		ArgOfPericenter 81.1
-		MeanAnomaly     169.8
+	EllipticalOrbit {             # fully specified orientation
+		Period          15.81
+		SemiMajorAxis    1.86 # mass ratio 0.124:0.113
+		Eccentricity     0.30
+		Inclination     29.15
+		AscendingNode  357.44
+		ArgOfPericenter 80.72
+		MeanAnomaly    172.43
 	}
 }
 
 "FL Vir:Gliese 473 B:Wolf 424 B"
 {
 	OrbitBarycenter "Wolf 424"
-	SpectralType "M5.0V"
-	Radius 140000 # approx. for class
-	AppMag 13.24
+	SpectralType "M5.5V"
+	AppMag 13.17
 
-	EllipticalOrbit {
-		Period          15.9
-		SemiMajorAxis   2.06 # mass ratio 0.14:0.13
-		Eccentricity	0.3
-		Inclination	28.7
-		AscendingNode   359.5
-		ArgOfPericenter 261.1
-		MeanAnomaly     169.8
+	EllipticalOrbit {              # fully specified orientation
+		Period           15.81
+		SemiMajorAxis     2.04 # mass ratio 0.124:0.113
+		Eccentricity      0.30
+		Inclination      29.15
+		AscendingNode   357.44
+		ArgOfPericenter 260.72
+		MeanAnomaly     172.43
 	}
+}
+
+80824 # Wolf 1061
+{
+	RA 247.57524250
+	Dec -12.66258979
+	Distance 14.0458 # 232.2095 +/- 0.0630 mas
+	SpectralType "M3V"
+	AppMag 10.072
+}
+
+3829 # van Maanen's Star
+{
+	RA 12.29124338
+	Dec 5.38860920
+	Distance 14.0744 # 231.7375 +/- 0.0380 mas
+	SpectralType "DZ7.5"
+	AppMag 12.374
+}
+
+439 # Gliese 1
+{
+	RA 1.35178251
+	Dec -37.35736228
+	Distance 14.1725 # 230.1331 +/- 0.0600 mas
+	SpectralType "M2V"
+	AppMag 8.562
+}
+
+# parameters and low-quality parallax from Martin et al. (2018)
+"WISE 1639-6847:WISE J163940.83-684738.6"
+{
+	RA 249.921736
+	Dec -68.797280
+	Distance 14.302 # 228.05 +/- 8.93 mas
+	Texture "exo-class4night.*"
+	SpectralType "Y0Vpec"
+	Temperature 370 # approx.
+	Radius 60000 # approx.
+	AbsMag 50 # extremely low
 }
 
 "TZ Ari:Gliese 83.1:Luyten 1159-16"
 {
-	RA 30.055000
-	Dec 13.052222
-	Distance 14.509
-	SpectralType "M4.0V"
-	Radius 180000 # approx. for class
-	AppMag 12.31
-}
-
-86162 # Gliese 687
-{
-	RA 264.107917
-	Dec 68.339167
-	Distance 14.794
-	SpectralType "M3.0V"
-	Radius 270000 # approx. for class
-	AppMag 9.17
-}
-
-"GJ 3622:LP 731-58"
-{
-	RA 162.052500
-	Dec -11.337222
-	Distance 14.805
-	SpectralType "M6.5V"
-	Radius 94000 # approx. for class
-	AppMag 15.73
-}
-
-Barycenter "GJ 1245" # orbit of A & B components unknown
-{
-	RA 298.477317   # mass ratio (0.11+0.07):0.10
-	Dec 44.415377   #
-	Distance 14.812
-}
-
-Barycenter "GJ 1245 A"
-{
-	RA 298.475833
-	Dec 44.415278
-	Distance 14.812
-}
-
-
-"V1581 Cyg:GJ 1245 Aa"
-{
-	OrbitBarycenter "GJ 1245 A"
-	SpectralType "M5.5V"
-	Radius 122000 # approx. for class
-	AppMag 13.46
-
-	EllipticalOrbit {
-		Period          15.22
-		SemiMajorAxis   0.49 # mass ratio 0.11:0.07
-		Eccentricity	0.32
-		Inclination	20
-		AscendingNode   197
-		ArgOfPericenter 58
-		MeanAnomaly     40
-	}
-}
-
-"GJ 1245 Ab"
-{
-	OrbitBarycenter "GJ 1245 A"
-	SpectralType "M7.5V" # from low luminosity
-	Radius 80000 # approx. for estimated class
-	AppMag 16.75
-
-	EllipticalOrbit {
-		Period          15.22
-		SemiMajorAxis   0.78 # mass ratio 0.11:0.07
-		Eccentricity	0.32
-		Inclination	20
-		AscendingNode   197
-		ArgOfPericenter 238
-		MeanAnomaly     40
-	}
-}
-
-"GJ 1245 B"
-{
-	RA 298.480000
-	Dec 44.415556
-	Distance 14.812
-	SpectralType "M6.0V"
-	Radius 105000 # approx. for class
-	AppMag 14.01
+	RA 30.05398414
+	Dec 13.05195036
+	Distance 14.5843 # 223.6349 +/- 0.1066 mas
+	SpectralType "M4.5V"
+	AppMag 12.298
 }
 
 85523 # Gliese 674
 {
-	RA 262.166250
-	Dec -46.895278
-	Distance 14.818
-	SpectralType "M2.5V"
-	Radius 290000 # approx. for class
-	AppMag 9.37
+	RA 262.16643984
+	Dec -46.89519257
+	Distance 14.8387 # 219.8012 +/- 0.0487 mas
+	SpectralType "M3V"
+	AppMag 9.407
+}
+
+86162 # Gliese 687
+{
+	RA 264.10791321
+	Dec 68.33914004
+	Distance 14.8401 # 219.7807 +/- 0.0324 mas
+	SpectralType "M3.0V"
+	AppMag 9.15
+}
+
+"Gliese 3622:LP 731-58"
+{
+	RA 162.05255937
+	Dec -11.33600262
+	Distance 14.8851 # 219.1159 +/- 0.1567 mas
+	SpectralType "M6.5V"
+	AppMag 15.784
 }
 
 57367 # Luyten 145-141
 {
-	RA 176.428750
-	Dec -64.841389
-	Distance 15.092
+	RA 176.42882111
+	Dec -64.84151780
+	Distance 15.1182 # 215.7373 +/- 0.0324 mas
 	SpectralType "DQ6"
-	AppMag 11.50
+	AppMag 11.513
 }
 
-113020 # Ross 780
+113020 # Gliese 687
 {
-	RA 343.319583
-	Dec -14.263611
-	Distance 15.208
+	RA 343.31971796
+	Dec -14.26369539
+	Distance 15.2504 # 213.8669 +/- 0.0758 mas
 	SpectralType "M3.5V"
-	Radius 225000 # approx. for class
-	AppMag 10.18
+	AppMag 10.192
 }
 
-"GJ 1002"
+# masses from Benedict et al. (2016), AJ 152 (5), 141
+# "The Solar Neighborhood. XXXVII: The Mass-Luminosity Relation for Main-sequence
+# M Dwarfs"
+# http://iopscience.iop.org/article/10.3847/0004-6256/152/5/141/meta
+Barycenter "Gliese 1245" # orbit of A & B components unknown
 {
-	RA 1.682500
-	Dec -7.539444
-	Distance 15.313
+	RA 298.477317   # mass ratio (0.111:0.076):0.10
+	Dec 44.415377
+	Distance 15.268
+}
+
+Barycenter "Gliese 1245 A"
+{
+	RA 298.47700882
+	Dec 44.41426155
+	Distance 15.3029 # 213.1329 +/- 0.5737 mas
+}
+
+"V1581 Cyg:Gliese 1245 Aa"
+{
+	OrbitBarycenter "Gliese 1245 A"
+	SpectralType "M5.5V"
+	AppMag 13.46
+
+	EllipticalOrbit {              # fully specified orientation
+		Period           16.84
+		SemiMajorAxis     1.53 # mass ratio 0.111:0.076
+		Eccentricity      0.33
+		Inclination      70.45
+		AscendingNode    37.06
+		ArgOfPericenter 208.50
+		MeanAnomaly       2.21
+	}
+}
+
+"Gliese 1245 Ab"
+{
+	OrbitBarycenter "Gliese 1245 A"
+	SpectralType "M7.5V"
+	AppMag 16.75
+
+	EllipticalOrbit {             # fully specified orientation
+		Period          16.84
+		SemiMajorAxis    2.23 # mass ratio 0.111:0.076
+		Eccentricity     0.33
+		Inclination     70.45
+		AscendingNode   37.06
+		ArgOfPericenter 28.50
+		MeanAnomaly      2.21
+	}
+}
+
+"Gliese 1245 B"
+{
+	RA 298.47974513
+	Dec 44.41504008
+	Distance 15.2034 # 214.5285 +/- 0.0824 mas
+	SpectralType "M6V"
+	AppMag 13.99
+}
+
+"Gliese 3618:Luyten 143-23"
+{
+	RA 161.08847255
+	Dec -61.20979537
+	Distance 15.7703 # 206.8172 +/- 0.0735 mas 
 	SpectralType "M5.0V"
-	Radius 140000 # approx. for class
-	AppMag 13.77
+	AppMag 13.920
 }
 
-"GJ 3618:Luyten 143-23"
+"Gliese 1002"
 {
-	RA 161.132500
-	Dec -61.193889
-	Distance 15.554
+	RA 1.67998846
+	Dec -7.53806229
+	Distance 15.8164 # 206.2134 +/- 0.1281 mas
 	SpectralType "M5.5V"
 	Radius 122000 # approx. for class
-	AppMag 13.92
+	AppMag 13.837
 }
 
+# masses from Mann et al. (2015), ApJ 804 (1), 64
+# "How to Constrain Your M Dwarf: Measuring Effective Temperature, 
+# Bolometric Luminosity, Mass, and Radius"
+# http://iopscience.iop.org/article/10.1088/0004-637X/804/1/64/meta
 Barycenter 54211 "Gliese 412:Lalande 21258" # orbits of A & B unknown
 {
-	RA 166.370443   # mass ratio 0.48:0.10
-	Dec 43.525816   #
-	Distance 15.859
+	RA 166.3709615  # mass ratio 0.39:0.0952
+	Dec 43.52576672
+	Distance 15.846
 }
 
 "Gliese 412 A:Lalande 21258 A"
 {
-	RA 166.369167
-	Dec 43.526667
-	Distance 15.859
-	SpectralType "M1.0V"
-	Radius 341000 # approx. for class
-	AppMag 8.77
+	RA 166.36907492
+	Dec 43.52677540
+	Distance 15.812 # 206.27 +/- 1.00 mas
+	SpectralType "M1.0Ve"
+	AppMag 8.780
 }
 
 "WX UMa:Gliese 412 B:Lalande 21258 B"
 {
-	RA 166.376667
-	Dec 43.521667
-	Distance 15.859
-	SpectralType "M5.5V"
-	Radius 122000 # approx. for class
-	AppMag 14.44
+	RA 166.37869018
+	Dec 43.52163453
+	Distance 15.9834 # 204.0592 +/- 0.1687 mas
+	SpectralType "M6.0V"
+	AppMag 14.45
 }
 
 49908 # Groombridge 1618
 {
-	RA 152.842083
-	Dec 49.454167
-	Distance 15.869
-	SpectralType "K7.0V"
-	AppMag 6.59
-}
-
-1001741423 "AD Leo:Gliese 388"
-{
-	RA 154.901667
-	Dec 19.869444
-	Distance 15.942
-	SpectralType "M2.5V"
-	AppMag 9.29
-}
-
-# Kirkpatrick et al. (2011) The First Hundred Brown Dwarfs 
-# Discovered by the Wide-field Infrared Survey Explorer (WISE)
-# http://arxiv.org/abs/1108.4677
-"WISE 1506+7027:WISE J1506+7027:WISEPC J150649.97+702736.0"
-{
-	RA 226.708333
-	Dec 70.460000
-	Distance 16
-	SpectralType "T6.0"
-	AbsMag 33.5 # for approximate radius in Celestia
-}
-
-# Artigau et al. DENIS J081730.0-615520: An overlooked mid-T 
-# dwarf in the solar neighborhood
-# http://arxiv.org/abs/1006.3577
-"DENIS 0817-6155:DENIS-P J081730.0-615520:2MASS 0817-6155:2MASS J08173001-6155158"
-{
-	RA 124.375000
-	Dec -61.921111
-	Distance 16.07
-	SpectralType "T6.0"
-	AbsMag 33.5 # for approximate radius in Celestia
-}
-
-106440 # Luyten 354-89
-{
-	RA 323.391667
-	Dec -49.008889
-	Distance 16.144
-	SpectralType "M1.5V"
-	Radius 324000 # approx. for class
-	AppMag 8.66
-}
-
-"LP 944-20"
-{
-	Texture "browndwarf.*"
-	RA 54.896667
-	Dec -35.428056
-	Distance 16.195
-	SpectralType "M9.0V"
-	Radius 56000 # approx. for class
-	AppMag 18.69
+	RA 152.84225009
+	Dec 49.45423588
+	Distance 15.8797 # 205.3917 +/- 0.0342 mas
+	SpectralType "K6Ve"
+	AppMag 6.61
 }
 
 "DENIS 0255-4700:DENIS-P J025503.5-470050:2MASS 0255-4700:2MASS J02550357-4700509"
 {
-	RA 43.765417
-	Dec -47.014444
-	Distance 16.197
-	SpectralType "L7.5V"
+	RA 43.76539377
+	Dec -47.01426260
+	Distance 15.8847 # 205.3266 +/- 0.2545 mas
+	SpectralType "L9V"
 	Radius 70000 # approx.
-	AppMag 22.92
+	AppMag 22.921
 }
 
-Barycenter 19849 "Keid:OMI2 Eri:40 Eri:Gliese 166:ADS 3093" # Orbits of A & (BC) unknown
+106440 # Gliese 832
 {
-	RA 63.828351    # mass ratio 0.89:(0.5+0.20)
-	Dec -7.655829   #
-	Distance 16.255
+	RA 323.39156247
+	Dec -49.00900096
+	Distance 16.1939 # 201.4073 +/- 0.0429 mas
+	SpectralType "M2V"
+	Radius 306000 # approx. for class
+	AppMag 8.672
 }
 
-"Keid A:OMI2 Eri A:40 Eri A:Gliese 166 A:ADS 3093 A"
+1001741423 "AD Leo:Gliese 388"
 {
-	RA 63.817917
-	Dec -7.652778
-	Distance 16.255
-	SpectralType "K0.5V"
+	RA 154.90117001
+	Dec 19.87000390
+	Distance 16.1970 # 201.3683 +/- 0.0679 mas
+	SpectralType "M4Vae"
+	Radius 180000 # approx. for class
+	AppMag 9.52
+}
+
+# mass of component A from Ma et al. (2018), MNRAS 480 (2), 2411
+# "The first super-Earth detection from the high cadence and high radial velocity 
+# precision Dharma Planet Survey"
+# https://arxiv.org/abs/1807.07098
+Barycenter "Keid:OMI2 Eri:40 Eri:Gliese 166:ADS 3093" # Orbits of A & (BC) unknown
+{
+	RA 63.82884851   # mass ratio 0.78:(0.573:0.2036)
+	Dec -7.654310215
+	Distance 16.305
+}
+
+19849 "Keid A:OMI2 Eri A:40 Eri A:Gliese 166 A:ADS 3093 A"
+{
+	RA 63.81799886
+	Dec -7.65287169
+	Distance 16.257 # 200.62 +/- 0.23 mas
+	SpectralType "K0V"
 	AppMag 4.43
 }
 
 Barycenter "Keid BC:OMI2 Eri BC:40 Eri BC:Gliese 166 BC"
 {
-	RA 63.841667
-	Dec -7.659722
-	Distance 16.255
+	RA 63.83974566
+	Dec -7.65575504
+	Distance 16.3523 # 199.4552 mas
 }
 
+# radius from Bond et al. (2017), ApJ 848 (1), 16
+# "Astrophysical Implications of a New Dynamical Mass for the 
+# Nearby White Dwarf 40 Eridani B"
+# http://iopscience.iop.org/article/10.3847/1538-4357/aa8a63/meta
 "Keid B:OMI2 Eri B:40 Eri B:Gliese 166 B:ADS 3093 B"
 {
 	OrbitBarycenter "Keid BC"
-	SpectralType "DA4"
-	AppMag 9.52
+	SpectralType "DA3"
+	Radius 9100
+	AppMag 9.53
 
 	EllipticalOrbit {
-		Period          252.1
-		SemiMajorAxis   9.97   # mass ratio 0.5:0.2
-		Eccentricity	0.41
-		Inclination	84.4
-		AscendingNode   215.2
-		ArgOfPericenter 90.4
-		MeanAnomaly     214.77
+		Period         230.30
+		SemiMajorAxis    9.11 # mass ratio 0.573:0.2036
+		Eccentricity     0.43
+		Inclination     84.13
+		AscendingNode  216.59
+		ArgOfPericenter 80.71
+		MeanAnomaly     44.31
 	}
 }
 
 "Keid C:OMI2 Eri C:40 Eri C:DY Eri:Gliese 166 C:ADS 3093 C"
 {
 	OrbitBarycenter "Keid BC"
-	SpectralType "M4.0V"
+	SpectralType "M4.5V"
 	Radius 180000 # approx. for class
-	AppMag 11.24
+	AppMag 11.17
 
 	EllipticalOrbit {
-		Period          252.1
-		SemiMajorAxis   24.92  # mass ratio 0.5:0.2
-		Eccentricity	0.41
-		Inclination	84.4
-		AscendingNode   215.2
-		ArgOfPericenter 270.4
-		MeanAnomaly     214.77
+		Period           230.3
+		SemiMajorAxis    25.64 # mass ratio 0.573:0.2036
+		Eccentricity      0.43
+		Inclination      84.13
+		AscendingNode   216.59
+		ArgOfPericenter 260.71
+		MeanAnomaly      44.31
 	}
-}
-
-112460 # EV Lac
-{
-	RA 341.702083
-	Dec 44.330833
-	Distance 16.455
-	SpectralType "M3.5V"
-	Radius 225000 # approx. for class
-	AppMag 10.22
 }
 
 86214 # Gliese 682
 {
-	RA 264.265417
-	Dec -44.319167
-	Distance 16.465
-	SpectralType "M4.0V"
+	RA 264.26527385
+	Dec -44.31921360
+	Distance 16.3320 # 199.7031 +/- 0.0832 mas
+	SpectralType "M3.5V"
 	Radius 180000 # approx. for class
-	AppMag 10.95
+	AppMag 10.946
 }
 
+112460 # EV Lac
+{
+	RA 341.70721323
+	Dec 44.33399228
+	Distance 16.4716 # 198.0112 +/- 0.0380 mas
+	SpectralType "M4.0V"
+	Radius 225000 # approx. for class
+	AppMag 10.26
+}
+
+# Masses from same source as orbit
 Barycenter 88601 "70 Oph:Gliese 702:ADS 11046:Struve 2272"
 {
-	RA 271.363750 
-	Dec 2.500000
-	Distance 16.644
+	RA 271.36368827
+	Dec 2.50009883
+	Distance 16.580 # 196.72 +/- 0.83 mas
 }
 
 "70 Oph A:Gliese 702 A:ADS 11046 A:Struve 2272 A"
 {
 	OrbitBarycenter "70 Oph"
 	SpectralType "K0V"
-	AppMag 4.21
+	AppMag 4.13
 
-	EllipticalOrbit {
-		Period           88.34
-		SemiMajorAxis    10.55 # mass ratio 0.88:0.73
+	EllipticalOrbit {              # fully specified orientation
+		Period           88.44
+		SemiMajorAxis    10.37 # mass ratio 0.89:0.73
 		Eccentricity      0.50
-		Inclination     116.40
-		AscendingNode   331.07
-		ArgOfPericenter 341.25
-		MeanAnomaly      63.90
+		Inclination      28.75
+		AscendingNode    73.59
+		ArgOfPericenter 285.57
+		MeanAnomaly      63.92
 	}
 }
 
 "70 Oph B:Gliese 702 B:ADS 11046 B:Struve 2272 B"
 {
 	OrbitBarycenter "70 Oph"
-	SpectralType "K5V"
-	AppMag 6.01
+	SpectralType "K4V"
+	AppMag 6.07
 
-	EllipticalOrbit {
-		Period           88.34
-		SemiMajorAxis    12.72 # mass ratio 0.88:0.73
+	EllipticalOrbit {              # fully specified orientation
+		Period           88.44
+		SemiMajorAxis    12.64 # mass ratio 0.89:0.73
 		Eccentricity      0.50
-		Inclination     116.40
-		AscendingNode   331.07
-		ArgOfPericenter 161.25
-		MeanAnomaly      63.90
+		Inclination      28.75
+		AscendingNode    73.59
+		ArgOfPericenter 105.57
+		MeanAnomaly      63.92
 	}
 }
 
+# rotational parameters from Monnier et al. (2007), Science 317 (5836), 342
+# "Imaging the Surface of Altair"
+# https://arxiv.org/abs/0706.0867
 97649 # Altair
 {
-	RA 297.695833
-	Dec 8.868333
-	Distance 16.692
+	RA 297.69582730
+	Dec 8.86832120
+	Distance 16.730 # 194.95 +/- 0.57
 	SpectralType "A7IV"
-	AppMag 0.77
+	AppMag 0.76
 
-	RotationPeriod 10.4
-	SemiAxes [ 1 0.88 1 ] # equatorial radius 14% greater than polar
+	SemiAxes [ 1 0.81 1 ] # equatorial radius 24% greater than polar
+
+	UniformRotation
+	{
+		Period         10.4
+		Inclination    77.86 # inclination (i) = 57.2 deg
+		AscendingNode 252.65 # orientation (alpha) = -61.8 deg
+	}
 }
 
 Barycenter "GJ 1116"  # orbit of A & B unknown
 {
-	RA 134.562083   # mass ratio 0.11:0.10
-	Dec 19.762724   #
-	Distance 17.059
+	RA 134.5629579  # mass ratio 0.11:0.10
+	Dec 19.76308611
+	Distance 16.735
 }
 
 "EI Cnc:GJ 1116 A"
 {
-	RA 134.562083
-	Dec 19.761944
-	Distance 17.059
-	SpectralType "M5.5V"
-	Radius 122000 # approx. for class
-	AppMag 14.06
+	RA 134.56280747
+	Dec 19.76340108
+	Distance 16.7498 # 194.7225 +/- 0.1251 mas
+	SpectralType "M8Ve"
+	Radius 76500 # approx. for class
+	AppMag 13.93
 }
 
 "GJ 1116 B:LP 426-40"
 {
-	RA 134.562083
-	Dec 19.763611
-	Distance 17.059
-	SpectralType "M5.5V"
-	Radius 122000 # approx. for class
-	AppMag 14.92
+	RA 134.56312344
+	Dec 19.76273963
+	Distance 16.7189 # 195.0836 +/- 0.1754 mas
+	SpectralType "M7V"
+	Radius 83500 # approx. for class
+	AppMag 13.75
+}
+
+# rotation period from Burningham et al. (2016), MNRAS 463 (2), 2202
+# "A LOFAR mini-survey for low-frequency radio emission from the nearest brown
+# dwarfs"
+# https://academic.oup.com/mnras/article/463/2/2202/2892466
+"WISE 1506+7027:WISE J150649.97+702736.1"
+{
+	RA 226.71850107
+	Dec 70.45697728
+	Distance 16.8516 # 193.5457 +/- 0.9420 mas
+	AppMag 17.48 # calculated from J, H, and Ks bands
+	SpectralType "T6"
+	RotationPeriod 1.74
+	Temperature 1000
 }
 
 1006050134 "GJ 3379:Giclas 99-49"
 {
-	RA 90.015000
-	Dec 2.705556
-	Distance 17.097
-	SpectralType "M3.5V"
+	RA 90.01459942
+	Dec 2.70655466
+	Distance 16.9813 # 192.0675 +/- 0.0715 mas
+	SpectralType "M3.5Ve"
 	Radius 225000 # approx. for class
 	AppMag 11.31
 }
 
-"GJ 3323:LP 656-38:RECONS 3"
+"WISE J0817-6155:WISEP J081729.74-615504.1"
 {
-	RA 75.487500
-	Dec -6.946389
-	Distance 17.357
-	SpectralType "M4.0V"
-	Radius 180000 # approx. for class
-	AppMag 12.22
+	RA 124.37499532
+	Dec -61.92101733
+	Distance 17.0290 # 191.5301 +/- 0.6037 mas
+	SpectralType "T6V"
+	AbsMag 34 # for approximate radius in Celestia
 }
 
-# Leggett S.K. et al. (2009) "The phyical properties of four
-# 600K T dwarfs." ApJ, 695, 1517.
-# (http://arxiv.org/abs/0901.4093)
+57544 # Gliese 445
+{
+	RA 176.92245210
+	Dec 78.69116094
+	Distance 17.1424 # 190.2625 +/- 0.0475 mas
+	SpectralType "M4.0Ve"
+	Radius 181000 # approx. for class
+	AppMag 10.84
+}
+
+# magnitude from Perez Garrido et al. (2014), A&A 567, A6
+# "2MASS J154043.42-510135.7: a new addition to the 5 pc population"
+# https://www.aanda.org/articles/aa/abs/2014/07/aa23615-14/aa23615-14.html
+"WISE 1540-5101:WISE J154045.65-510139.2"
+{
+	RA 235.18140398
+	Dec -51.02665765
+	Distance 17.3441 # 191.5301 +/- 0.6037 mas
+	SpectralType "M6.5"
+	Radius 83500 # approx. for class
+	AppMag 15.26 # measured w/ ESO Faint Object Spectrograph and Camera
+}
+
+# Leggett et al. (2009), ApJ 695, 1517
+# "The phyical properties of four 600K T dwarfs."
+# http://iopscience.iop.org/article/10.1088/0004-637X/695/2/1517/meta
 # unresolved binary; separation and orbit unknown
 "2MASS 0939-2448 A:2MASS J09393548-2448279 A"
 {
 	Texture "exo-class4night.*"
-	RA 144.897823
-	Dec -24.80775
-	Distance 17.414
+	RA 144.897865
+	Dec -24.807761
+	Distance 17.414 # 187.30 +/- 4.60 mas
 	SpectralType "T8V"
 	Temperature 600
 	Radius 60000 # approx.
@@ -1341,91 +1400,130 @@ Barycenter "GJ 1116"  # orbit of A & B unknown
 "2MASS 0939-2448 B:2MASS J09393548-2448279 B"
 {
 	Texture "exo-class4night.*"
-	RA 144.897843
-	Dec -24.80775
-	Distance 17.414
+	RA 144.897885
+	Dec -24.807761
+	Distance 17.414 # 187.30 +/- 4.60 mas
 	SpectralType "T8V"
 	Temperature 600
 	Radius 60000 # approx.
 	AbsMag 50 # extremely low
 }
 
-57544 # Gliese 445
+"GJ 3323:LP 656-38:RECONS 3"
 {
-	RA 176.922500
-	Dec 78.691111
-	Distance 17.418
-	SpectralType "M3.5V"
-	Radius 225000 # approx. for class
-	AppMag 10.79
+	RA 75.48927544
+	Dec -6.94621441
+	Distance 17.5331 # 186.0231 +/- 0.0590
+	SpectralType "M4.0Ve"
+	Radius 180000 # approx. for class
+	AppMag 12.196
 }
 
 67155 # Lalande 25372
 {
-	RA 206.432500
-	Dec 14.891389
-	Distance 17.657
-	SpectralType "M1.0V"
-	Radius 341000 # approx. for class
-	AppMag 8.46
+	RA 206.43239772
+	Dec 14.89152033
+	Distance 17.7274 # 183.9836 +/- 0.0509
+	SpectralType "M2V"
+	Radius 306000 # approx. for class
+	AppMag 8.50
 }
 
-# Kirpatrick et al. (2011) The First Hundred Brown Dwarfs 
-# Discovered by the Wide-field Infrared Survey Explorer (WISE)
-# http://arxiv.org/abs/1108.4677
-"WISE 1741+2553:WISE J1741+2553:WISEPA J174124.26+255319.5"
+# mass ratio from Sahu et al. (2017), Science 356 (6342), 1046
+# "Relativistic deflection of background starlight measures the mass of 
+# a nearby white dwarf star"
+# https://arxiv.org/abs/1706.02037
+# orbit listed in Sixth Orbit Catalogue is of poor quality, so unused
+Barycenter 21088 "Gliese 169.1:Stein 2051"
 {
-	Texture "exo-class4night.*"
-	RA 265.351250
-	Dec 25.888889
-	Distance 17.9
-	SpectralType "T9.0"
-	Temperature 500 # approx.
-	Radius 60000 # approx.
-	AbsMag 50 # extremely low
-}
-
-Barycenter 21088 "Gliese 169.1:Stein 2051" # orbit of A & B unknown
-{
-	RA 67.796397    # mass ratio 0.224:0.50
-	Dec 58.977167   # 
-	Distance 18.068
+	RA 67.79800245  # mass ratio MB/MA 2.07
+	Dec 58.97707796
+	Distance 18.020
 }
 
 "Gliese 169.1 A:Stein 2051 A"
 {
-	RA 67.799375
-	Dec 58.977167
-	Distance 18.068
+	RA 67.79795272
+	Dec 58.97706349
+	Distance 18.0774 # 180.4215 +/- 0.5863 mas
 	SpectralType "M4V"
 	Radius 180000 # approx. for class
-	AppMag 11.04
+	AppMag 10.977
 }
 
 1020623744 "Gliese 169.1 B:Stein 2051 B"
 {
-	RA 67.795063
-	Dec 58.977167
-	Distance 18.068
+	RA 67.80237894
+	Dec 58.97813685
+	Distance 17.9917 # 181.2815 +/- 0.0450 mas
 	SpectralType "DC5"
-	AppMag 12.43
+	AppMag 11.19
 }
 
 33226 # Wolf 294
 {
-	RA 103.704167
-	Dec 33.268056
-	Distance 18.313
-	SpectralType "M3.0V"
+	RA 103.70399048
+	Dec 33.26817738
+	Distance 18.2043 # 179.1642 +/- 0.0632 mas
+	SpectralType "M3V"
 	Radius 270000 # approx. for class
-	AppMag 10.02
+	AppMag 10.11
+}
+
+103039 # LP 816-60
+{
+	RA 313.13756964
+	Dec -16.97472438
+	Distance 18.3106 # from 178.1243 +/- 0.0849 mas
+	SpectralType "M4V"
+	Radius 181000 # approx. for class
+	AppMag 11.458
+}
+
+# parallax from Faherty et al. (2012), ApJ 752, (1), 56
+# "The Brown Dwarf Kinematics Project (BDKP). III. Parallaxes for 70 Ultracool Dwarfs"
+# http://iopscience.iop.org/article/10.1088/0004-637X/752/1/56/meta
+# radius and temperature from Line et al. (2017), ApJ 848 (2), 83
+# "Uniform Atmospheric Retrieval Analysis of Ultracool Dwarfs. II. Properties 
+# of 11 T dwarfs"
+# http://iopscience.iop.org/0004-637X/848/2/83/
+"2MASS 1114-2618:2MASS J11145133-2618235"
+{
+	Texture "exo-class4night.*"
+	RA 168.713904
+	Dec -26.306544
+	Distance 18.45 # 176.8 +/- 7.0 mas
+	SpectralType "T7.5V"
+	Temperature 680
+	Radius 64000
+	AbsMag 50 # extremely low
+}
+
+# parallax from Marsh et al. (2013), ApJ 762 (2), 119
+# "Parallaxes and Proper Motions of Ultracool Brown Dwarfs of Spectral
+# Types Y and Late T"
+# http://iopscience.iop.org/article/10.1088/0004-637X/762/2/119/meta
+# rotation period, radius from Burningham et al. (2016), MNRAS 463, 2
+# "A LOFAR mini-survey for low-frequency radio emission from the nearest brown dwarfs"
+# https://academic.oup.com/mnras/article/463/2/2202/2892466
+"WISE 1741+2553:WISE J174124.25+255319.6"
+{
+	Texture "exo-class4night.*"
+	RA 265.352586
+	Dec 25.892878
+	Distance 18.53 # 176 +/- 25 mas
+	SpectralType "T9V"
+	Temperature 620
+	Radius 60000 # approx.
+	AbsMag 50 # extremely low
+	RotationPeriod 2
 }
 
 "2MASS 1835+3259:2MASS J18353790+3259545"
 {
-	RA 278.907917
-	Dec 32.998333
-	Distance 18.480
+	RA 278.90783482
+	Dec 32.99814204
+	Distance 18.5501 # from 175.8244 +/- 0.0905 mas
 	SpectralType "M8.5V"
 	Radius 66000 # approx. for class
 	AppMag 18.27
@@ -1433,151 +1531,112 @@ Barycenter 21088 "Gliese 169.1:Stein 2051" # orbit of A & B unknown
 
 25878 # Wolf 1453
 {
-	RA 82.864167
-	Dec -3.677222
-	Distance 18.533
-	SpectralType "M1.0V"
-	AppMag 7.95
+	RA 82.86414936
+	Dec -3.67722821
+	Distance 18.5919 # from 175.4287 +/- 0.0672 mas
+	SpectralType "M1.5Ve"
+	AppMag 7.968
 }
 
-103039 # LP 816-60
-{
-	RA 313.137500
-	Dec -16.974722
-	Distance 18.635
-	SpectralType "M3.5V"
-	Radius 225000 # approx. for class
-	AppMag 11.50
-}
-
+# coordinates, parallax from Dupuy & Liu (2012), ApJS 201 (2), 19
+# "The Hawaii Infrared Parallax Program. I. Ultracool Binaries and the L/T Transition"
+# http://iopscience.iop.org/article/10.1088/0067-0049/201/2/19/meta
 "2MASS 0415-0935:2MASS J04151954-0935066"
 {
 	Texture "exo-class4night.*"
-	RA 63.83125
-	Dec -9.585
-	Distance 18.709
+	RA 63.8381022
+	Dec -9.5835266
+	Distance 18.62 # 175.2 +/- 1.7 mas
 	SpectralType "T8.0V"
-	Temperature 760
+	Temperature 750
 	Radius 60000 # approx.
 	AbsMag 50 # extremely low
 }
 
 96100 # Sig Dra
 {
-	RA 293.090000
-	Dec 69.661111
-	Distance 18.768
-	SpectralType "G9V"
-	AppMag 4.67
+	RA 293.08995958
+	Dec 69.66117632
+	Distance 18.769 # 173.77 +/- 0.18 mas
+	SpectralType "K0V"
+	AppMag 4.680
 }
 
 Barycenter 29295 "Gliese 229:Luyten 668-21:LPM 230" # orbit of A & B unknown
 {
-	RA 92.644265    # mass ratio 0.556:0.05
-	Dec -21.864482  #
-	Distance 18.770
+	RA 92.64426427  # mass ratio 0.556:0.05
+	Dec -21.8644676
+	Distance 18.7775 # 173.6955 +/- 0.0457 mas
 }
 
 "Gliese 229 A:Luyten 668-21 A:LPM 230 A"
 {
-	RA 92.644231
-	Dec -21.864643
-	Distance 18.770
-	SpectralType "M1.5V"
-	Radius 324000 # approx. for class
-	AppMag 8.14
+	RA 92.64423021
+	Dec -21.86462723
+	Distance 18.7775
+	SpectralType "M1V"
+	Radius 341000 # approx. for class
+	AppMag 8.125
 }
 
 "Gliese 229 B:Luyten 668-21 B:LPM 230 B"
 {
 	RA 92.644643
 	Dec -21.862692
-	Distance 18.770
-	SpectralType "T6.0V"
+	Distance 18.7775
+	SpectralType "T6.5V"
 	AbsMag 33.5 # for approximate radius in Celestia
 }
 
 26857 # Ross 47
 {
-	RA 85.538750
-	Dec 12.489444
-	Distance 19.018
-	SpectralType "M4.0V"
+	RA 85.53861374
+	Dec 12.48933659
+	Distance 18.8850 # 172.7068 +/- 0.0788 mas
+	SpectralType "M4V"
 	Radius 180000 # approx. for class
-	AppMag 11.57
+	AppMag 11.509
 }
 
-86990 # Luyten 205-128
-{
-	RA 266.642500
-	Dec -57.319167
-	Distance 19.063
-	SpectralType "M3.0V"
-	Radius 270000 # approx. for class
-	AppMag 10.76
-}
-
-Barycenter 94761 "Gliese 752:Ross 652:Wolf 1055" # orbit of A & B unknown
-{
-	RA 289.232026   # mass ratio 0.494:0.073
-	Dec 5.166493    #
-	Distance 19.078
-}
-
-"V1428 Aql:Gliese 752 A:Ross 652 A:Wolf 1055 A"
-{
-	RA 289.230417
-	Dec 5.1688889
-	Distance 19.078
-	SpectralType "M2.5V"
-	Radius 290000 # approx. for class
-	AppMag 9.10
-}
-
-"Van Biesbroek's Star:V1298 Aql:Gliese 752 B:Ross 652 B:Wolf 1055 B:VB 10"
-{
-	RA 289.242917
-	Dec 5.150278
-	Distance 19.078
-	SpectralType "M8.0V"
-	Radius 77000 # approx. for class
-	AppMag 17.45
-}
-
+# mass and radius of A from Demory et al. (2009), A&A 505 (1), 205
+# "Mass-radius relation of low and very low-mass stars revisited with the VLTI"
+# https://www.aanda.org/articles/aa/full_html/2009/37/aa11976-09/aa11976-09.html
+# masses of B, C from same sources as orbit
 Barycenter "Gliese 570:ADS 9446"
 {
-	RA  224.363404  # mass ratio 0.76:(0.49+0.34)
-	Dec -21.413381  #
-	Distance 19.116
+	RA 224.363313679 # mass ratio 0.802:(0.586:0.390)
+	Dec -21.41332223
+	Distance 19.1844 # 170.0112 +/- 0.0851 mas
 }
 
-73184 "KX Lib:Gliese 570 A:ADS 9446 A"	# fully specified orientation
+73184 "KX Lib:Gliese 570 A:ADS 9446 A"
 {
 	OrbitBarycenter "Gliese 570"
 	SpectralType "K4V"
 	AppMag 5.64
+	Radius 514100
 
-	EllipticalOrbit {
-		Period         2130
-		SemiMajorAxis    99.39  # mass ratio 0.76:(0.49+0.34)
-		Eccentricity      0.2
-		Inclination     142.62
-		AscendingNode   191.56
+	EllipticalOrbit {             # fully specified orientation
+		Period           2130
+		SemiMajorAxis   104.4 # mass ratio 0.802:(0.586:0.390)
+		Eccentricity     0.20
+		Inclination     142.6
+		AscendingNode   191.6
 		ArgOfPericenter 129.2
 		MeanAnomaly      52.6
 	}
 }
 
-Barycenter 73182 "Gliese 570 BC"         # fully specified orientation
+Barycenter 73182 "Gliese 570 BC"
 {
 	OrbitBarycenter "Gliese 570"
 
-	EllipticalOrbit {
-		Period         2130
-		SemiMajorAxis    91.01  # mass ratio 0.76:(0.49+0.34)
-		Eccentricity      0.2
-		Inclination     142.62
-		AscendingNode   191.56
+	EllipticalOrbit {             # fully specified orientation
+		Period           2130
+		SemiMajorAxis    85.8 # mass ratio 0.802:(0.586:0.390)
+		Eccentricity     0.20
+		Inclination     142.6
+		AscendingNode   191.6
 		ArgOfPericenter 309.2
 		MeanAnomaly      52.6
 	}
@@ -1588,16 +1647,16 @@ Barycenter 73182 "Gliese 570 BC"         # fully specified orientation
 	OrbitBarycenter "Gliese 570 BC"
 	SpectralType "M1.5V"
 	Radius 324000 # approx. for class
-	AppMag 8.30
+	AppMag 8.33
 
-	EllipticalOrbit {
-		Period            0.847
-		SemiMajorAxis     0.34 # mass ratio 0.49:0.34
+	EllipticalOrbit {              # fully specified orientation
+		Period            0.846
+		SemiMajorAxis     0.35 # mass ratio 0.586:0.390
 		Eccentricity      0.76
-		Inclination      93.84
-		AscendingNode   246.91
-		ArgOfPericenter 214.71
-		MeanAnomaly      34.00
+		Inclination      90.68
+		AscendingNode    30.52
+		ArgOfPericenter 221.92
+		MeanAnomaly      45.19
 	}
 }
 
@@ -1606,163 +1665,199 @@ Barycenter 73182 "Gliese 570 BC"         # fully specified orientation
 	OrbitBarycenter "Gliese 570 BC"
 	SpectralType "M3V"
 	Radius 270000 # approx. for class
-	AppMag 9.96
+	AppMag 9.94
 
-	EllipticalOrbit {
-		Period            0.847
-		SemiMajorAxis     0.48 # mass ratio 0.49:0.34
-		Eccentricity      0.76
-		Inclination      93.84
-		AscendingNode   246.91
-		ArgOfPericenter  34.71
-		MeanAnomaly      34.00
+	EllipticalOrbit {              # fully specified orientation
+		Period           0.846
+		SemiMajorAxis    0.53 # mass ratio 0.586:0.390
+		Eccentricity     0.76
+		Inclination     90.68
+		AscendingNode   30.52
+		ArgOfPericenter 41.92
+		MeanAnomaly     45.19
 	}
 }
 
+# radius and temperature from Line et al. (2015), ApJ 807 (2), 183
+# "Uniform Atmospheric Retrieval Analysis of Ultracool Dwarfs. I. Characterizing
+# Benchmarks, Gl 570D and HD 3651B"
+# http://iopscience.iop.org/article/10.1088/0004-637X/807/2/183/meta
 "Gliese 570 D:ADS 9446 D"
 {
 	Texture "exo-class4night.*"
-	RA 224.312500
-	Dec -21.363889
-	Distance 19.116
-	SpectralType "T7.5V"
-	Temperature 750
-	Radius 60000 # approx.
+	RA 224.31233
+	Dec -21.36328
+	Distance 19.184
+	SpectralType "T8V"
+	Temperature 710
+	Radius 80000
 	AbsMag 50 # extremely low
+}
+
+86990 # Luyten 205-128
+{
+	RA 266.64263979
+	Dec -57.31904446
+	Distance 19.2013 # 169.8613 +/- 0.1184 mas
+	SpectralType "M3.5V"
+	Radius 225000 # approx. for class
+	AppMag 10.783
+}
+
+117473 # Gliese 908
+{
+	RA 357.30218808
+	Dec 2.40122307
+	Distance 19.2583 # 169.3585 +/- 0.0595 mas
+	SpectralType "M1V"
+	Radius 341000 # approx. for class
+	AppMag 8.993
+}
+
+# Parameters of A from Karminski et al. (2018), A&A 618, A115
+# "The CARMENES search for exoplanets around M dwarfs. A Neptune-mass
+# planet traversing the habitable zone around HD 180617"
+# https://arxiv.org/abs/1808.01183
+# Parameters of B from Tsuji et al. (2016), PASJ 68 (1), 1331
+# "Near-infrared spectroscopy of M dwarfs. III. Carbon and oxygen abundances
+# in late M dwarfs, including the dusty rapid rotator 2MASSI J1835379+325954"
+# https://arxiv.org/abs/1511.04682
+Barycenter 94761 "Gliese 752:Ross 652:Wolf 1055" # orbit of A & B unknown
+{
+	RA 289.231870107 # mass ratio 0.45:0.09
+	Dec 5.1658232850
+	Distance 19.2810 # 169.1590 +/- 0.0520 mas
+}
+
+"V1428 Aql:Gliese 752 A:Ross 652 A:Wolf 1055 A"
+{
+	RA 289.23023552
+	Dec 5.16889968
+	Distance 19.2810
+	SpectralType "M2.5V"
+	Radius 315000
+	AppMag 9.115
+	RotationPeriod 1105
+}
+
+"Van Biesbroek's Star:V1298 Aql:Gliese 752 B:Ross 652 B:Wolf 1055 B:VB 10"
+{
+	RA 289.242917
+	Dec 5.150278
+	Distance 19.2810 # used Gaia DR parallax of A
+	SpectralType "M8.0V"
+	Radius 86000
+	AppMag 17.30
 }
 
 "Gliese 754:Luyten 347-14"
 {
-	RA 290.200833
-	Dec -45.558889
-	Distance 19.280
-	SpectralType "M4.0V"
+	RA 290.19993122
+	Dec -45.55823034
+	Distance 19.2887 # 169.0921 +/- 0.2165 mas
+	SpectralType "M4.5V"
 	Radius 180000 # approx. for class
 	AppMag 12.23
 }
 
 76074 # Gliese 588
 {
-	RA 233.053750
-	Dec -41.275556
-	Distance 19.355
+	RA 233.05388594
+	Dec -41.27559211
+	Distance 19.2983 # 169.0074 +/- 0.0580 mas
 	SpectralType "M2.5V"
 	Radius 290000 # approx. for class
-	AppMag 9.31
+	AppMag 9.311
 }
 
-Barycenter 1242 "GJ 1005:Luyten 722-22"
+# parameters from Martin et al. (2018)
+"WISE 0350âˆ’5658:WISE J035000.32-565830.2"
 {
-	RA 3.867083
-	Dec -16.133889
-	Distance 19.374
+	RA 57.500996
+	Dec -56.975638
+	Distance 19.317 # 168.84 +/- 8.53 mas
+	Texture "exo-class4night.*"
+	SpectralType "Y1V"
+	Temperature 300
+	Radius 60000 # approx.
+	AbsMag 50 # extremely low
 }
 
-"GJ 1005 A:Luyten 722-22 A"
-{
-	OrbitBarycenter "Luyten 722-22"
-	SpectralType "M3.5V"
-	Radius 225000 # approx. for class
-	AppMag 11.60
-
-	EllipticalOrbit {
-		Period          4.566
-		SemiMajorAxis   0.62  # mass ratio 0.18:0.11
-		Eccentricity	0.364
-		Inclination	72.3
-		AscendingNode   85.2
-		ArgOfPericenter 169.4
-		MeanAnomaly     5.4
-	}
-}
-
-"GJ 1005 B:Luyten 722-22 B"
-{
-	OrbitBarycenter "Luyten 722-22"
-	SpectralType "M7V"
-	Radius 84000 # approx. for class
-	AppMag 14.02
-
-	EllipticalOrbit {
-		Period          4.566
-		SemiMajorAxis   1.01  # mass ratio 0.18:0.11
-		Eccentricity	0.364
-		Inclination	72.3
-		AscendingNode   85.2
-		ArgOfPericenter 349.4
-		MeanAnomaly     5.4
-	}
-}
-
+# Used Gaia DR2 parallax for B
 Barycenter 3821 "Achird:ETA Cas:24 Cas:Gliese 34:ADS 671"
 {
-	RA 12.27625
-	Dec 57.815278
-	Distance 19.388
+	RA 12.274657128 # mass ratio 1.07:0.55
+	Dec 57.81608312
+	Distance 19.328 # 168.7521 +/- 0.0377 mas
 }
 
+# Mass ratio from theoretical values from same source as orbit
 "Achird A:ETA Cas A:24 Cas A:Gliese 34 A:ADS 671 A"
 {
-	OrbitBarycenter "Achird"
-	SpectralType "G3V"
-	AppMag 3.46
+	OrbitBarycenter "ETA Cas"
+	SpectralType "G0V"
+	AppMag 3.44
 
 	EllipticalOrbit {
-		Period          480
-		SemiMajorAxis   24.99  # mass ratio 1.11:0.60
-		Eccentricity    0.497
-		Inclination	152.19
-		AscendingNode   6.96
-		ArgOfPericenter 179.63
-		MeanAnomaly     82.80
+		Period          479.27
+		SemiMajorAxis    24.22 # mass ratio 1.07:0.55
+		Eccentricity      0.50
+		Inclination     152.40
+		AscendingNode     8.78
+		ArgOfPericenter 182.11
+		MeanAnomaly      82.68
 	}
 }
 
 "Achird B:ETA Cas B:24 Cas B:Gliese 34 B:ADS 671 B"
 {
-	OrbitBarycenter "Achird"
-	SpectralType "K7.0V"
-	AppMag 7.21
+	OrbitBarycenter "ETA Cas"
+	SpectralType "K7V"
+	AppMag 7.51
 
 	EllipticalOrbit {
-		Period          480
-		SemiMajorAxis   46.24  # mass ratio 1.11:0.60
-		Eccentricity    0.497
-		Inclination	152.19
-		AscendingNode   6.96
-		ArgOfPericenter 359.63
-		MeanAnomaly     82.80
+		Period        479.27
+		SemiMajorAxis  47.12 # mass ratio 1.07:0.55
+		Eccentricity    0.50
+		Inclination   152.40
+		AscendingNode   8.78
+		ArgOfPericenter 2.11
+		MeanAnomaly    82.68
 	}
 }
 
 Barycenter "36 Oph:Gliese 663:ADS 10417" # orbit of (AB) & C unknown
 {
-	RA 258.901180   # mass ratio (0.85+0.85):0.7
-	Dec -26.586250  #
-	Distance 19.401
+	RA 258.907618286 # mass ratio (0.75:0.76):0.72
+	Dec -26.58414637
+	Distance 19.4373
 }
 
+# Distance from average of distances from Gaia DR2 parallax for A and B
 Barycenter 84405 "36 Oph AB:Gliese 663 AB"
 {
-	RA 258.837500
-	Dec -26.602778
-	Distance 19.401
+	RA 258.837020242 # mass ratio 0.75:0.76
+	Dec -26.60226476 # A: 167.8221 +/- 0.1556 mas
+	Distance 19.4373 # B: 167.7764 +/- 0.2210 mas
 }
 
+# Average masses from Luck, R. E. (2017), AJ 153 (1), 21
+# "Abundances in the Local Region II: F, G, and K Dwarfs and Subgiants"
+# http://iopscience.iop.org/article/10.3847/1538-3881/153/1/21/meta
 "36 Oph A:Gliese 663 A:ADS 10417 A"
 {
 	OrbitBarycenter "36 Oph AB"
-	SpectralType "K1.5V"
-	AppMag 5.07
+	SpectralType "K2V"
+	AppMag 5.08
 
 	EllipticalOrbit {
 		Period          470.9
-		SemiMajorAxis   38.8  # mass ratio 0.85:0.85
-		Eccentricity    0.916
-		Inclination	13.35
+		SemiMajorAxis    38.99 # mass ratio 0.75:0.76
+		Eccentricity      0.92
+		Inclination      13.35
 		AscendingNode   348.86
-		ArgOfPericenter 271.0
-		MeanAnomaly     246.3
+		ArgOfPericenter 270.97
+		MeanAnomaly     246.27
 	}
 }
 
@@ -1773,226 +1868,285 @@ Barycenter 84405 "36 Oph AB:Gliese 663 AB"
 	AppMag 5.08
 
 	EllipticalOrbit {
-		Period          470.9
-		SemiMajorAxis   38.8  # mass ratio 0.85:0.85
-		Eccentricity    0.916
-		Inclination	13.35
-		AscendingNode   348.86
-		ArgOfPericenter 91.0
-		MeanAnomaly     246.3
+		Period         470.9
+		SemiMajorAxis   38.48 # mass ratio 0.75:0.76
+		Eccentricity     0.92
+		Inclination     13.35
+		AscendingNode  348.86
+		ArgOfPericenter 90.97
+		MeanAnomaly    246.27
 	}
 }
 
 84478 "36 Oph C:V2215 Oph:Gliese 664:Gliese 663 C:ADS 10417 C"
 {
-	RA 259.055833
-	Dec -26.546111
-	Distance 19.401
+	RA 259.05567807
+	Dec -26.5461481
+	Distance 19.4373 # used same distance as A and B
 	SpectralType "K5V"
-	AppMag 6.32
+	AppMag 6.34
 }
 
-117473 # Gliese 908
+# parameters from Martin et al. (2018)
+# BT-Settl model parameters from Beichman et al. (2014), ApJ 783 (2), 68
+# "WISE Y Dwarfs as Probes of the Brown Dwarf-Exoplanet Connection"
+# https://iopscience.iop.org/article/10.1088/0004-637X/783/2/68/meta
+"WISE 1541-2250:WISE J1541-2250:WISEPA J154151.66-225025.2"
 {
-	RA 357.302083
-	Dec 2.401111
-	Distance 19.412
-	SpectralType "M1.0V"
-	Radius 341000 # approx. for class
-	AppMag 8.98
+	Texture "exo-class4night.*"
+	RA 235.464061
+	Dec -22.840554
+	Distance 19.524 # 167.05 +/- 4.19 mas
+	SpectralType "Y1"
+	Temperature 350
+	Radius 69900
+	AbsMag 50 # extremely low
 }
 
 37766 # Ross 882 
 {
-	RA 116.167500
-	Dec 3.552500
-	Distance 19.509
+	RA 116.16738595
+	Dec 3.55246606
+	Distance 19.5281 # 167.0186 +/- 0.0592 mas
 	SpectralType "M4.0V"
 	Radius 180000 # approx. for class
-	AppMag 11.19
+	AppMag 11.225
+}
+
+# masses and parallaxes from Benedict et al. (2016), AJ 152 (5), 141
+# "The Solar Neighborhood. XXXVII: The Mass-Luminosity Relation for Main-sequence
+# M Dwarfs"
+# http://iopscience.iop.org/article/10.3847/0004-6256/152/5/141/meta
+Barycenter 1242 "GJ 1005:Luyten 722-22"
+{
+	RA 3.86712874
+	Dec -16.133786
+	Distance 19.577 # 166.6 +/- 0.3 mas
+}
+
+"GJ 1005 A:Luyten 722-22 A"
+{
+	OrbitBarycenter "GJ 1005"
+	SpectralType "M3.5V"
+	AppMag 11.60
+
+	EllipticalOrbit {              # fully specified orientation
+		Period           4.565
+		SemiMajorAxis     0.70 # mass ratio 0.179:0.112
+		Eccentricity      0.36
+		Inclination      72.44
+		AscendingNode    85.33
+		ArgOfPericenter 182.79
+		MeanAnomaly       5.81
+	}
+}
+
+"GJ 1005 B:Luyten 722-22 B"
+{
+	OrbitBarycenter "GJ 1005"
+	SpectralType "M7V"
+	AppMag 14.02
+
+	EllipticalOrbit {            # fully specified orientation
+		Period         4.565
+		SemiMajorAxis   1.12 # mass ratio 0.179:0.112
+		Eccentricity    0.36
+		Inclination    72.44
+		AscendingNode  85.33
+		ArgOfPericenter 2.79
+		MeanAnomaly     5.81
+	}
 }
 
 Barycenter 99461 "Gliese 783:CD-36 13940:J Herschel 5173:HJ 5173" # orbit of A & B unknown
 {
-	RA 302.798770   # mass ratio 0.82:0.20
-	Dec -36.097603  #
+	RA 302.7999508  # mass ratio 0.82:0.20
+	Dec -36.1014624
 	Distance 19.618
 }
 
 "Gliese 783 A:CD-36 13940 A:J Herschel 5173 A:HJ 5173 A"
 {
-	RA 302.79837
-	Dec -36.097385
-	Distance 19.618
+	RA 302.79974369
+	Dec -36.10120932
+	Distance 19.6211 # 166.2274 +/- 0.1256 mas
 	SpectralType "K2.5V"
-	AppMag 5.31
+	AppMag 5.32
 }
 
 "Gliese 783 B:CD-36 13940 B:J Herschel 5173 B:HJ 5173 B"
 {
-	RA 302.8004
-	Dec -36.09849
-	Distance 19.618
-	SpectralType "M4.0V"
+	RA 302.8008
+	Dec -36.10250
+	Distance 19.6211
+	SpectralType "M3.5V"
 	Radius 180000 # approx. for class
 	AppMag 11.50
 }
 
 15510 # 82 Eri
 {
-	RA 49.981667
-	Dec -43.069722
-	Distance 19.711
-	SpectralType "G8V"
-	AppMag 4.26
+	RA 49.98187890
+	Dec -43.06978264
+	Distance 19.711 # 165.47 +/- 0.19 mas
+	SpectralType "G6V"
+	AppMag 4.27
 }
 
-# Kirpatrick et al. (2011) The First Hundred Brown Dwarfs 
-# Discovered by the Wide-field Infrared Survey Explorer (WISE)
-# http://arxiv.org/abs/1108.4677
-"WISE 0254+0223:WISE J0254+0223:WISEPA J025409.45+022359.1"
-{
-	Texture "exo-class4night.*"
-	RA 43.539583
-	Dec 2.399722
-	Distance 19.8
-	SpectralType "T8.0"
-	Temperature 500
-	Radius 60000 # approx.
-	AbsMag 50 # extremely low
-}
-
-"GJ 1221:LP 44-113"
-{
-	RA 267.027917
-	Dec 70.874722
-	Distance 19.804
-	SpectralType "DXP9"
-	AppMag 14.22
-}
-
-Barycenter "Gliese 338:ADS 7251:Struve 1321"
-{
-	RA 138.598959
-	Dec 52.775278
-	Distance 19.921
-}
-
-45343 "Gliese 338 A:ADS 7251 A:Struve 1321 A"
-{
-	OrbitBarycenter "Struve 1321"
-	SpectralType "M0V"
-	Radius 432000 # approx. for class
-	AppMag 7.64
-
-	EllipticalOrbit {
-		Period          975
-		SemiMajorAxis   51.58  # mass ratio 06:0.6
-		Eccentricity    0.28
-		Inclination	113
-		AscendingNode   13
-		ArgOfPericenter 276
-		MeanAnomaly     264
-	}
-}
-
-120005 "Gliese 338 B:ADS 7251 B:Struve 1321 B"
-{
-	OrbitBarycenter "Struve 1321"
-	SpectralType "K7V"
-	AppMag 7.70
-
-	EllipticalOrbit {
-		Period          975
-		SemiMajorAxis   51.58  # mass ratio 06:0.6
-		Eccentricity    0.28
-		Inclination	113
-		AscendingNode   13
-		ArgOfPericenter 96
-		MeanAnomaly     264
-	}
-}
-
-99240 # Del Pav
-{
-	RA 302.181667
-	Dec -66.181944
-	Distance 19.923
-	SpectralType "G8IV"
-	AppMag 3.55
-}
-
-# Delfosse, X. et al. (1999) "New Neighbours I: 13 new
-# companions to nearby M dwarfs" A&A, 344, 897
-# (http://arxiv.org/abs/astro-ph/9812008)
+# Barry et al. (2012), ApJ 760 (1), 55
+# "A Precise Physical Orbit for the M-dwarf Binary Gliese 268"
+# http://iopscience.iop.org/article/10.1088/0004-637X/760/1/55/meta
 Barycenter 34603 "Gliese 268:Ross 986"
 {
-	RA 107.5075
-	Dec 38.529444
-	Distance 19.960
+	RA 3.86712874
+	Dec -16.133786
+	Distance 19.8103 # 164.6395 +/- 0.1338 mas
 }
 
 "QY Aur:Gliese 268 A:Ross 986 A"
 {
-	OrbitBarycenter "Ross 986"
+	OrbitBarycenter "Gliese 268"
 	SpectralType "M4.5V"
-	Radius 160000 # approx. for class
 	AppMag 12.05
 
 	EllipticalOrbit {
-		Period          0.02856 # 10.43dy
-		SemiMajorAxis   0.03    # mass ratio 0.17:0.16
-		ArgOfPericenter 180
+		Period        0.028566
+		SemiMajorAxis    31.01 # mass ratio 0.22599:0.19248
+		Eccentricity      0.32
+		Inclination      35.99
+		AscendingNode   130.70
+		ArgOfPericenter 349.54
+		MeanAnomaly     248.39
 	}
 }
 
 "Gliese 268 B:Ross 986 B"
 {
-	OrbitBarycenter "Ross 986"
+	OrbitBarycenter "Gliese 268"
 	SpectralType "M6V"
-	Radius 105000 # approx. for class
 	AppMag 12.45
 
 	EllipticalOrbit {
-		Period          0.02856 # 10.43dy
-		SemiMajorAxis   0.03    # mass ratio 0.17:0.16
+		Period        0.028566
+		SemiMajorAxis    36.41 # mass ratio 0.22599:0.19248
+		Eccentricity      0.32
+		Inclination      35.99
+		AscendingNode   130.70
+		ArgOfPericenter 169.54
+		MeanAnomaly     248.39
 	}
 }
 
+99240 # Del Pav
+{
+	RA 302.18170612
+	Dec -66.18206758
+	Distance 19.923 # 163.71 +/- 0.17 mas
+	SpectralType "G8IV"
+	AppMag 3.56
+}
+
+"2MASS 0136+0933:2MASS J01365662+0933473:SIMP J013656.5+093347"
+{
+	RA 24.23566572
+	Dec 9.56314736
+	Distance 19.9261 # 163.6824 +/- 0.7223 mas
+	SpectralType "T2.5V"
+	AbsMag 27.5 # for approximate radius in Celestia
+}
+
+# parallax from Faherty et al. (2012), ApJ 752, (1), 56
+# "The Brown Dwarf Kinematics Project (BDKP). III. Parallaxes for 70 Ultracool Dwarfs"
+# http://iopscience.iop.org/article/10.1088/0004-637X/752/1/56/meta
 "2MASS 0937+2931:2MASS J09373487+2931409"
 {
-	RA 144.391667
-	Dec 29.516667
-	Distance 19.973
+	RA 144.395333
+	Dec 29.528056
+	Distance 19.961 # 163.39 +/- 1.76 mas
 	SpectralType "T6.0V"
-	AbsMag 33.5  # for approximate radius in Celestia
+	AbsMag 33.5 # for approximate radius in Celestia
 }
 
 99701 # Gliese 784
 {
-	RA 303.472500
-	Dec -45.163889
-	Distance 20.215
-	SpectralType "M0.0V"
+	RA 303.47248496
+	Dec -45.16402041
+	Distance 20.0932 # 162.3212 +/- 0.0495 mas
+	SpectralType "M0V"
 	Radius 432000 # approx. for class
-	AppMag 7.95
+	AppMag 7.966
+}
+
+# Masses from same source as orbit
+Barycenter "WISE 0720-0846:WISE J072003.20-084651.2"
+{
+	RA 110.01355700
+	Dec -8.78052900
+	Distance 20.22 # 6.2 +/- 0.7 pc
+}
+
+# Apparent magnitude of A from Ivanov et al. (2015), A&A 574, A64
+# "Properties of the solar neighbor WISE J072003.20-084651.2"
+# https://www.aanda.org/articles/aa/abs/2015/02/aa24883-14/aa24883-14.html
+"WISE J0720-0846 A:WISE J072003.20-084651.2 A"
+{
+	OrbitBarycenter "WISE 0720-0846"
+	SpectralType "M9.5V"
+	AppMag 18.266
+
+	EllipticalOrbit {
+		Period            3.1
+		SemiMajorAxis     1.34 # mass ratio 0.081:0.062
+		Eccentricity      0.80
+		Inclination      39.0
+		AscendingNode   175.8
+		ArgOfPericenter 257.4
+		MeanAnomaly     203.2
+	}
+}
+
+"WISE J0720-0846 B:WISE J072003.20-084651.2 B"
+{
+	OrbitBarycenter "WISE 0720-0846"
+	SpectralType "T5.5V"
+	AbsMag 32 # for approximate radius in Celestia
+
+	EllipticalOrbit {
+		Period           3.1
+		SemiMajorAxis    1.76 # mass ratio 0.081:0.062
+		Eccentricity     0.80
+		Inclination     39.0
+		AscendingNode  175.8
+		ArgOfPericenter 77.4
+		MeanAnomaly    203.2
+	}
+}
+
+"GJ 1221:LP 44-113"
+{
+	RA 267.03330405
+	Dec 70.87664478
+	Distance 20.2604 # 160.9819 +/- 0.0143 mas
+	SpectralType "DQ9P"
+	AppMag 14.15
 }
 
 71253 # Gliese 555
 {
-	RA 218.570000
-	Dec -12.519444
-	Distance 20.286
-	SpectralType "M4.0V"
-	Radius 180000 # approx. for class
-	AppMag 11.32
+	RA 218.57004817
+	Dec -12.51956038
+	Distance 20.3702 # 160.1141 +/- 0.1135 mas
+	SpectralType "M3.5V"
+	Radius 225000 # approx. for class
+	AppMag 11.317
 }
 
+# Distance from average of distances from Gaia DR2 parallax for A and B
 Barycenter 116132 "Gliese 896"
 {
-	RA 352.967500
-	Dec 19.937222
-	Distance 20.401
+	RA 352.96797137 # mass ratio (0.34:0.13):(0.16:0.09)
+	Dec 19.93724591 # A: 159.7098 +/- 0.0827 mas
+	Distance 20.400 # B: 160.0598 +/- 0.1079 mas
 }
 
 Barycenter "Gliese 896 A"
@@ -2000,25 +2154,25 @@ Barycenter "Gliese 896 A"
 	OrbitBarycenter "Gliese 896"
 
 	EllipticalOrbit {
-		Period          359
-		SemiMajorAxis   15.12  # mass ratio (0.34+0.13):(0.16+0.09)
-		Eccentricity    0.2
-		Inclination	19.6
+		Period            359
+		SemiMajorAxis    14.92 # mass ratio (0.34:0.13):(0.16:0.09)
+		Eccentricity      0.2
+		Inclination      19.6
 		AscendingNode   138.8
 		ArgOfPericenter 119.1
 		MeanAnomaly     352.0
 	}
 }
- 
+
 Barycenter "Gliese 896 B"
 {
 	OrbitBarycenter "Gliese 896"
 
 	EllipticalOrbit {
-		Period          359
-		SemiMajorAxis   28.44  # mass ratio (0.34+0.13):(0.16+0.09)
-		Eccentricity    0.2
-		Inclination	19.6
+		Period            359
+		SemiMajorAxis    28.0 # mass ratio (0.34:0.13):(0.16:0.09)
+		Eccentricity      0.2
+		Inclination      19.6
 		AscendingNode   138.8
 		ArgOfPericenter 299.1
 		MeanAnomaly     352.0
@@ -2033,11 +2187,11 @@ Barycenter "Gliese 896 B"
 	AppMag 10.27
 
 	EllipticalOrbit {
-		Period          3.5	# "of the order of a few years"
-		SemiMajorAxis   0.5	# mass ratio 0.34:0.13
+		Period          3.5 # "of the order of a few years"
+		SemiMajorAxis   0.5 # mass ratio 0.34:0.13
+		Inclination	 20 # to match orbital plane of system
+		AscendingNode   140
 		ArgOfPericenter 180
-		Inclination	20	# to match orbital plane
-		AscendingNode   140     # of system
 	}
 
 }
@@ -2045,15 +2199,15 @@ Barycenter "Gliese 896 B"
 "Gliese 896 Ab"
 {
 	OrbitBarycenter "Gliese 896 A"
-	SpectralType "M7V"              # from apparent magnitude
+	SpectralType "M7V" # from apparent magnitude
 	Radius 84000 # approx. for estimated class
 	AppMag 13.26
 
 	EllipticalOrbit {
-		Period          3.5	# "of the order of a few years"
-		SemiMajorAxis   1.2	# mass ratio 0.34:0.13
-		Inclination	20	# to match orbital plane
-		AscendingNode   140     # of system
+		Period          3.5 # "of the order of a few years"
+		SemiMajorAxis   1.2 # mass ratio 0.34:0.13
+		Inclination	 20 # to match orbital plane of system
+		AscendingNode   140
 	}
 }
 
@@ -2065,63 +2219,96 @@ Barycenter "Gliese 896 B"
 	AppMag 12.21
 
 	EllipticalOrbit {
-		Period          4.1	# "of the order of a few years"
-		SemiMajorAxis   0.6	# mass ratio 0.16:0.09
+		Period          4.1 # "of the order of a few years"
+		SemiMajorAxis   0.6 # mass ratio 0.16:0.09
+		Inclination	 20 # to match orbital plane of system
+		AscendingNode   140
 		ArgOfPericenter 180
-		Inclination	20	# to match orbital plane
-		AscendingNode   140     # of system
 	}
 }
 
 "Gliese 896 Bb"
 {
 	OrbitBarycenter "Gliese 896 B"
-	SpectralType "M9V"              # from apparent magnitude
+	SpectralType "M9V" # from apparent magnitude
 	Radius 56000 # approx. for class
 	AppMag 15.40
 
 	EllipticalOrbit {
-		Period          4.1	# "of the order of a few years"
-		SemiMajorAxis   1.0	# mass ratio 0.16:0.09
-		Inclination	20	# to match orbital plane
-		AscendingNode   140     # of system
+		Period          4.1 # "of the order of a few years"
+		SemiMajorAxis   1.0 # mass ratio 0.16:0.09
+		Inclination	 20 # to match orbital plane of system
+		AscendingNode   140
 	}
 }
 
-74995 # Wolf 562
+74995 # Gliese 581
 {
-	RA 229.861667
-	Dec -7.722222
-	Distance 20.669
-	SpectralType "M3.0V"
+	RA 229.86177972
+	Dec -7.72227527
+	Distance 20.5454 # 158.7492 +/- 0.0523 mas
+	SpectralType "M3V"
 	Radius 270000 # approx. for class
-	AppMag 10.57
+	AppMag 10.560
+}
+
+# Distance from average of distances from Gaia DR2 parallax for A and B
+Barycenter "Gliese 338:ADS 7251:Struve 1321"
+{
+	RA 138.59887190 # mass ratio 0.60:0.60
+	Dec 52.68648597 # A: 157.8796 +/- 0.0366 mas
+	Distance 20.658 # B: 157.8851 +/- 0.0414 mas
+}
+
+45343 "Gliese 338 A:ADS 7251 A:Struve 1321 A"
+{
+	OrbitBarycenter "ADS 7251"
+	SpectralType "K7V"
+	AppMag 7.63
+
+	EllipticalOrbit {
+		Period         975
+		SemiMajorAxis   51 # mass ratio 0.6:0.6
+		Eccentricity  0.28
+		Inclination    113
+		AscendingNode   13
+		ArgOfPericenter 97
+		MeanAnomaly    264
+	}
+}
+
+120005 "Gliese 338 B:ADS 7251 B:Struve 1321 B"
+{
+	OrbitBarycenter "ADS 7251"
+	SpectralType "M0V"
+	Radius 432000 # approx. for class
+	AppMag 7.70
+
+	EllipticalOrbit {
+		Period          975
+		SemiMajorAxis    52 # mass ratio 0.6:0.6
+		Eccentricity   0.28
+		Inclination     113
+		AscendingNode    13
+		ArgOfPericenter 277
+		MeanAnomaly     264
+	}
 }
 
 "LHS 2090:LP 368-128"
 {
-	RA 135.098333
-	Dec 21.834722
-	Distance 20.792
-	SpectralType "M6.0V"
+	RA 135.09811222
+	Dec 21.83469395
+	Distance 20.8063 # 156.7584 +/- 0.1329 mas
+	SpectralType "M6.5V"
 	Radius 105000 # approx. for class
-	AppMag 16.10
-}
-
-"LHS 337:Luyten 471-42:GJ 3737"
-{
-	RA 189.704583
-	Dec -38.381667
-	Distance 20.804
-	SpectralType "M4.0V"
-	Radius 180000 # approx. for class
-	AppMag 12.75
+	AppMag 16.100
 }
 
 Barycenter 84140 "Gliese 661:BD+45 2505"
 {
-	RA 258.032917
-	Dec 45.665833
+	RA 258.03296559
+	Dec 45.66589325
 	Distance 20.865
 }
 
@@ -2130,7 +2317,7 @@ Barycenter 84140 "Gliese 661:BD+45 2505"
 	OrbitBarycenter "Gliese 661"
 	SpectralType "M3V"
 	Radius 270000 # approx. for class
-	AppMag 9.93
+	AppMag 10.02
 
 	EllipticalOrbit {
 		Period           12.96
@@ -2148,7 +2335,7 @@ Barycenter 84140 "Gliese 661:BD+45 2505"
 	OrbitBarycenter "Gliese 661"
 	SpectralType "M4V"
 	Radius 180000 # approx. for class
-	AppMag 10.35
+	AppMag 10.25
 
 	EllipticalOrbit {
 		Period           12.96
@@ -2161,210 +2348,375 @@ Barycenter 84140 "Gliese 661:BD+45 2505"
 	}
 }
 
-# Artigau E. et al. (2006) Discovery of the brightest T dwarf in the 
-# northern hemisphere." ApJ, 651, L57.
-# (http://arxiv.org/abs/astro-ph/0609419)
-"2MASS 0136+0933:2MASS J01365662+0933473:SIMP J013656.5+093347"
+"LP 944-20"
 {
-	RA 24.235833
-	Dec 9.563056
-	Distance 20.874
-	SpectralType "T2.5V"
-	AbsMag 27.5  # for approximate radius in Celestia
+	RA 54.89688549
+	Dec -35.42878568
+	Distance 20.9398 # 155.7590 +/- 0.0991 mas
+	SpectralType "M9.5Ve"
+	Radius 56000 # approx. for class
+	Texture "browndwarf.*"
+	AppMag 18.69
 }
 
 "Gliese 223.2:LP 658-2:HL 4"
 {
-	RA 88.790417
-	Dec -4.171389
-	Distance 20.901
-	SpectralType "DZ9"
-	AppMag 14.47
+	RA 88.78971006
+	Dec -4.16862949
+	Distance 21.0084 # 155.2501 +/- 0.0287 mas
+	SpectralType "DZ11"
+	AppMag 14.45
 }
 
-"GJ 3959:Giclas 180-60"
+"2MASS 1503+2525:2MASS J15031961+2525196"
 {
-	RA 247.826667
-	Dec 40.865000
-	Distance 20.908
-	SpectralType "M5.0V"
-	Radius 140000 # approx. for class
-	AppMag 14.76
+	RA 225.83171067
+	Dec 25.42215925
+	Distance 21.0531 # 154.9208 +/- 1.1025 mas
+	SpectralType "T5.5V"
+	AbsMag 32 # for approximate radius in Celestia
 }
 
-# Delfosse, X. et al. (1999) "New Neighbours I: 13 new
-# companions to nearby M dwarfs" A&A, 344, 897
-# (http://arxiv.org/abs/astro-ph/9812008)
-# Mazeh, T. et al. (2001) "Studies of multiple stellar systems - IV. The
-# triple-lined spectroscopic system Gliese 644" MNRAS, 325, 343.
-# (http://arxiv.org/abs/astro-ph/0102451)
 Barycenter "Gliese 644:Wolf 630" # orbit of (AB) & C unknown
 {
-	RA 253.872083 # mass ratio (0.41+0.34+0.30):0.08
-	Dec -8.340536 #
-	Distance 21.048
+	RA 253.8717855 # mass ratio (0.4155:(0.3466:0.3143)):0.0841
+	Dec -8.3405565
+	Distance 21.080
 }
 
-Barycenter 82817 "Gliese 644 AB:Wolf 630 AB"
+# Parallax and masses from Segransan. et al. (2000), A&A 364, 665
+# "Accurate masses of very low mass stars. III. 16 new or improved masses"
+# http://adsabs.harvard.edu/abs/2000A%26A...364..665S
+Barycenter 82817 "Gliese 644 A-B:Wolf 630 A-B"
 {
-	RA 253.870000
-	Dec -8.336389
-	Distance 21.048
+	RA 253.86982326
+	Dec -8.3363299
+	Distance 21.070 # 154.8 +/- 0.6 mas
 }
 
 "V1054 Oph:Gliese 644 A:Wolf 630 A"
 {
-	OrbitBarycenter "Wolf 630 AB"
+	OrbitBarycenter "Gliese 644 A-B"
 	SpectralType "M2.5V"
-	Radius 290000 # approx. for class
-	AppMag 9.72
+	AppMag 9.73
 
-	EllipticalOrbit {                # fully specified orientation
-		Period          1.71727
-		SemiMajorAxis   0.86     # mass ratio 0.45:(0.34+0.30)
-		Eccentricity    0.043
-		Inclination	69.7
-		AscendingNode   0.1
-		ArgOfPericenter 224.0
-		MeanAnomaly     325.6
+	EllipticalOrbit {              # fully specified orientation
+		Period            1.718
+		SemiMajorAxis     0.90 # mass ratio 0.4155:(0.3466:0.3143)
+		Eccentricity      0.04
+		Inclination      82.15
+		AscendingNode   324.51
+		ArgOfPericenter 236.42
+		MeanAnomaly      63.52
 	}
 }
 
 Barycenter "Gliese 644 B:Wolf 630 B"
 {
-	OrbitBarycenter "Wolf 630 AB"
+	OrbitBarycenter "Gliese 644 A-B"
 
-	EllipticalOrbit {                # fully specified orientation
-		Period          1.71727
-		SemiMajorAxis   0.60     # mass ratio 0.45:(0.34+0.30)
-		Eccentricity    0.0433
-		Inclination	69.7
-		AscendingNode   0.1
-		ArgOfPericenter 44.0
-		MeanAnomaly     325.6
+	EllipticalOrbit {             # fully specified orientation
+		Period           1.718
+		SemiMajorAxis    0.57 # mass ratio 0.4155:(0.3466:0.3143)
+		Eccentricity     0.04
+		Inclination     82.15
+		AscendingNode  324.51
+		ArgOfPericenter 56.42
+		MeanAnomaly     63.52
 	}
 }
 
 "Gliese 644 Ba:Wolf 630 Ba"
 {
-	OrbitBarycenter "Wolf 630 B"
+	OrbitBarycenter "Gliese 644 B"
 	SpectralType "M3V"
-	Radius 270000 # approx. for class
-	AppMag 10.37
+	AppMag 10.54
 
 	EllipticalOrbit {
-		Period          0.008119 # 2.965522 dy
-		SemiMajorAxis   0.017	 # mass ratio 0.34:0.30
-		Eccentricity    0.026
-		Inclination	70       # orbit of Bab said to be
-		AscendingNode   0        # in same plane as AB
+		Period           0.008125 # 2.965509 d
+		SemiMajorAxis    0.0167 # mass ratio 0.3466:0.3143
+		Eccentricity     0.02 # axis calculated from mass and period
+		Inclination     80.81
+		AscendingNode  328.19 # assumed to be identical to A-B
+		ArgOfPericenter 79.87
+		MeanAnomaly    164.82
 	}
 }
 
 "Gliese 644 Bb:Wolf 630 Bb"
 {
-	OrbitBarycenter "Wolf 630 B"
+	OrbitBarycenter "Gliese 644 B"
 	SpectralType "M4V"
-	Radius 180000 # approx. for class
-	AppMag 10.87
+	AppMag 10.63
 
 	EllipticalOrbit {
-		Period          0.008119 # 2.965522 dy
-		SemiMajorAxis   0.018    # mass ratio 0.34:0.30
-		Eccentricity    0.026
-		Inclination	70       # orbit of Bab said to be
-		AscendingNode   0        # in same plane as AB
-		ArgOfPericenter	180
+		Period            0.008125 # 2.965509 d
+		SemiMajorAxis     0.0185 # mass ratio 0.3466:0.3143
+		Eccentricity      0.02 # axis calculated from mass and period
+		Inclination      80.81
+		AscendingNode   328.19 # assumed to be identical to A-B
+		ArgOfPericenter 259.87
+		MeanAnomaly     164.82
 	}
 }
 
+# Physical parameters from Mann et al. (2015), ApJ 804 (1), 64
+# "How to Constrain Your M Dwarf: Measuring Effective Temperature, 
+# Bolometric Luminosity, Mass, and Radius"
+# http://iopscience.iop.org/article/10.1088/0004-637X/804/1/64/meta
 "Gliese 644 C:Wolf 630 C:VB 8"
 {
-	RA 253.899167
-	Dec -8.394444
-	Distance 21.048
+	RA 253.89690059
+	Dec -8.39465358
+	Distance 21.2046 # 153.8139 +/- 0.1148 mas
 	SpectralType "M7V"
-	Radius 84000 # approx. for class
-	AppMag 16.78
+	AppMag 16.916
+	Radius 78680
 }
 
-82809 "Gliese 643:Wolf 629"
+"GL Vir:GJ 1156:Luyten 1190-34"
 {
-	RA 253.855000
-	Dec -8.322500
-	Distance 21.048
-	SpectralType "M3.5V"
-	Radius 225000 # approx. for class
-	AppMag 11.80
+	RA 184.74749966
+	Dec 11.12604729
+	Distance 21.1094 # 154.5077 +/- 0.1108 mas
+	SpectralType "M4.5V"
+	Radius 160000 # approx. for class
+	AppMag 13.898
 }
 
 80459 # Gliese 625
 {
-	RA 246.352500
-	Dec 54.304167
-	Distance 21.298
+	RA 246.35259712
+	Dec 54.30410160
+	Distance 21.1144 # 154.4710 +/- 0.0273 mas
 	SpectralType "M1.5V"
 	Radius 324000 # approx. for class
-	AppMag 10.10
+	AppMag 10.17
+}
+
+# parameters from Martin et al. (2018)
+# BT-Settl model parameters from Beichman et al. (2014), ApJ 783 (2), 68
+# "WISE Y Dwarfs as Probes of the Brown Dwarf-Exoplanet Connection"
+# https://iopscience.iop.org/article/10.1088/0004-637X/783/2/68/meta
+"WISE 2209+2711:WISE J220905.73+271143.9"
+{
+	RA 332.273892
+	Dec 27.195556
+	Distance 21.123 # 154.41 +/- 5.67 mas
+	Texture "exo-class4night.*"
+	SpectralType "Y0V"
+	Temperature 350
+	Radius 69900
+	AbsMag 50 # extremely low
+}
+
+82809 "Gliese 643:Wolf 629"
+{
+	RA 253.85508989
+	Dec -8.32258365
+	Distance 21.1901 # 153.9189 +/- 0.1310 mas
+	SpectralType "M3.5V"
+	Radius 225000 # approx. for class
+	AppMag 11.759
 }
 
 "GJ 1128:LHS 271:Luyten 100-115"
 {
-	RA 145.693333
-	Dec -68.885000
-	Distance 21.311
+	RA 145.69309184
+	Dec -68.88500107
+	Distance 21.2090 # 153.7816 +/- 0.0554 mas
+	SpectralType "M4.0V"
+	Radius 180000 # approx. for class
+	AppMag 12.78
+}
+
+# parameters from Martin et al. (2018)
+"WISE 0410+1502:WISE J041022.71+150248.4"
+{
+	RA 62.595853
+	Dec 15.044417
+	Distance 21.259 # 153.42 +/- 4.05 mas
+	Texture "exo-class4night.*"
+	SpectralType "Y0V"
+	Temperature 300 # approx.
+	Radius 60000 # approx.
+	AbsMag 50 # extremely low
+}
+
+114622 # Gliese 892
+{
+	RA 348.32072826
+	Dec 57.16835459
+	Distance 21.3061 # 153.0808 +/- 0.0895 mas
+	SpectralType "K3V"
+	AppMag 5.570
+}
+
+# BT-Settl model parameters from Beichman et al. (2014), ApJ 783 (2), 68
+# "WISE Y Dwarfs as Probes of the Brown Dwarf-Exoplanet Connection"
+# https://iopscience.iop.org/article/10.1088/0004-637X/783/2/68/meta
+"WISE 0313+7807:WISE J031325.94+780744.3"
+{
+	RA 048.358100
+	Dec 78.128986
+	Distance 21.3 # 153 +/- 15 mas
+	Texture "exo-class4night.*"
+	SpectralType "T8.5V"
+	Temperature 651
+	Radius 61500
+	AbsMag 50 # extremely low
+}
+
+"LHS 337:Luyten 471-42:GJ 3737"
+{
+	RA 189.70457636
+	Dec -38.38157547
+	Distance 21.7666 # 149.8423 +/- 0.0755 mas
 	SpectralType "M4.0V"
 	Radius 180000 # approx. for class
 	AppMag 12.74
 }
 
-"GL Vir:GJ 1156:Luyten 1190-34"
+# SÃ¶derhjelm, S. (1999), A&A 341, 121
+# "Visual binary orbits and masses post Hipparcos"
+# http://adsabs.harvard.edu/abs/1999A%26A...341..121S
+Barycenter 72659 "XI Boo:37 Boo:Gliese 566:ADS 9413"
 {
-	RA 184.751250
-	Dec 11.125278
-	Distance 21.332
-	SpectralType "M4.5V"
-	Radius 160000 # approx. for class
-	AppMag 13.80
+	RA 222.847018
+	Dec 19.100634
+	Distance 21.893 # 148.98 +/- 0.48 mas
 }
 
-114622 # Gliese 892
+"XI Boo A:37 Boo A:Gliese 566 A:ADS 9413 A"
 {
-	RA 348.320833
-	Dec 57.168333
-	Distance 21.340
-	SpectralType "K3V"
-	AppMag 5.57
+	OrbitBarycenter "XI Boo"
+	SpectralType "G7Ve"
+	AppMag 4.675
+
+	EllipticalOrbit {
+		Period          151.6
+		SemiMajorAxis    13.80 # mass ratio 0.94:0.67
+		Eccentricity      0.51
+		Inclination      83.21
+		AscendingNode   270.13
+		ArgOfPericenter 158.75
+		MeanAnomaly     215.38
+	}
 }
 
-"GJ 3877:LP 914-54"
+"XI Boo B:37 Boo B:Gliese 566 B:ADS 9413 B"
 {
-	RA 224.160417
-	Dec -28.164167
-	Distance 21.389
-	SpectralType "M7.0V"
-	Radius 84000 # approx. for class
-	AppMag 17.05
+	OrbitBarycenter "XI Boo"
+	SpectralType "K5Ve"
+	AppMag 6.816
+
+	EllipticalOrbit {
+		Period          151.6
+		SemiMajorAxis    19.36 # mass ratio 0.94:0.67
+		Eccentricity      0.51
+		Inclination      83.21
+		AscendingNode   270.13
+		ArgOfPericenter 338.75
+		MeanAnomaly     215.38
+	}
 }
 
 53767 # Ross 104
 {
-	RA 165.017917
-	Dec 22.833056
-	Distance 21.843
-	SpectralType "M2.5V"
-	Radius 290000 # approx. for class
-	AppMag 10.02
+	RA 165.01773737
+	Dec 22.83295740
+	Distance 22.0185 # 148.1283 +/- 0.0569 mas
+	SpectralType "M4V"
+	Radius 180000 # approx. for class
+	AppMag 10.020
 }
 
-# Delfosse, X. et al. (1999) "New Neighbours I: 13 new
-# companions to nearby M dwarfs" A&A, 344, 897
-# (http://arxiv.org/abs/astro-ph/9812008)
+# Tokovinin et al. (2015), AJ 150 (2), 50
+# "Speckle Interferometry at SOAR in 2014"
+# http://iopscience.iop.org/article/10.1088/0004-6256/150/2/50/meta
+# Delfosse et al. (1999), A&A 344, 897
+# "New neighbours. I. 13 new companions to nearby M dwarfs"
+# http://adsabs.harvard.edu/abs/1999A&A...344..897D
+Barycenter "GJ 3522:Giclas 41-14"
+{
+	RA 134.734670
+	Dec 8.4739078
+	Distance 22.088 # 147.66 +/- 1.98 mas
+}
+
+Barycenter "GJ 3522 A:Giclas 41-14 A"
+{
+	OrbitBarycenter "Giclas 41-14"
+	SpectralType "M3.5V"
+
+	EllipticalOrbit {
+		Period          5.566
+		SemiMajorAxis    0.86 # mass ratio (0.19:0.17):0.17
+		Eccentricity     0.78
+		Inclination    155.71
+		AscendingNode  234.28
+		ArgOfPericenter 34.91
+		MeanAnomaly    303.15
+	}
+}
+
+"GJ 3522 Aa:Giclas 41-14 Aa"
+{
+	OrbitBarycenter "Giclas 41-14 A"
+	SpectralType "M3.5V"
+	Radius 225000 # approx. for class
+	AppMag 11.94
+
+	EllipticalOrbit {
+		Period          0.021	# 7.6 d
+		SemiMajorAxis   0.0255	# estimated from mass ratio 0.19:0.17
+		Inclination     156     # guess - to match
+		AscendingNode   234     # plane of AB
+	}
+}
+
+"GJ 3522 Ab:Giclas 41-14 Ab"
+{
+	OrbitBarycenter "Giclas 41-14 A"
+	SpectralType "M6V" # from estimated mass
+	Radius 105000 # approx. for estimated class
+	AppMag 12.14
+
+	EllipticalOrbit {
+		Period          0.021	# 7.6 d
+		SemiMajorAxis   0.0285	# estimated from mass ratio 0.19:0.17
+		Inclination     156     # guess - to match
+		AscendingNode   234     # plane of AB
+		ArgOfPericenter 180
+	}
+}
+
+"GJ 3522 B:Giclas 41-14 B"
+{
+	OrbitBarycenter "Giclas 41-14"
+	SpectralType "M6V"
+	Radius 105000 # approx. for estimated class
+	AppMag 12.28
+
+	EllipticalOrbit {
+		Period           5.566
+		SemiMajorAxis     1.83 # mass ratio (0.19:0.17):0.17
+		Eccentricity      0.78
+		Inclination     155.71
+		AscendingNode   234.28
+		ArgOfPericenter 214.91
+		MeanAnomaly     303.15
+	}
+}
+
+# Delfosse et al. (1999), A&A 344, 897
+# "New neighbours. I. 13 new companions to nearby M dwarfs"
+# http://adsabs.harvard.edu/abs/1999A&A...344..897D
 Barycenter 106106 "Gliese 829:Ross 775"
 {
-	RA 322.400816
-	Dec 17.642376
-	Distance 21.889
+	RA 322.40338336
+	Dec 17.64329431
+	Distance 22.0954 # 147.6126 +/- 0.0979 mas
 }
 
 "Gliese 829 A:Ross 775 A"
@@ -2375,7 +2727,7 @@ Barycenter 106106 "Gliese 829:Ross 775"
 	AppMag 11.05
 
 	EllipticalOrbit {
-		Period          0.146	# 53.2dys
+		Period          0.146	# 53.2 d
 		SemiMajorAxis   0.11	# estimated from mass ratio 0.26:0.26
 		ArgOfPericenter 180
 	}
@@ -2389,170 +2741,337 @@ Barycenter 106106 "Gliese 829:Ross 775"
 	AppMag 11.05
 
 	EllipticalOrbit {
-		Period          0.146	# 53.2dys
+		Period          0.146	# 53.2 d
 		SemiMajorAxis   0.11	# estimated from mass ratio 0.26:0.26
 	}
 }
 
-# Kirkpatrick et al. (2011) The First Hundred Brown Dwarfs 
-# Discovered by the Wide-field Infrared Survey Explorer (WISE)
-# http://arxiv.org/abs/1108.4677
-"WISE 1217+1626:WISE J1217+1626:WISEPC J121756.91+162640.2"
-{
-	Texture "exo-class4night.*"
-	RA 184.487083
-	Dec 16.444444
-	Distance 21.9
-	SpectralType "T9.0V"
-	Temperature 600
-	Radius 60000 # approx.
-	AbsMag 50 # extremely low
-}
-
-# Delfosse, X. et al. (1999) "New Neighbours I: 13 new
-# companions to nearby M dwarfs" A&A, 344, 897
-# (http://arxiv.org/abs/astro-ph/9812008)
-Barycenter "GJ 3522:Giclas 41-14"
-{
-	RA 134.734583
-	Dec 8.473889
-	Distance 22.089
-}
-
-Barycenter "GJ 3522 A:Giclas 41-14 A"
-{
-	OrbitBarycenter "Giclas 41-14"
-
-	EllipticalOrbit {
-		Period          11.8	# estimate
-		SemiMajorAxis   1.3	# from AB separation and mass ratio (0.19+0.17):0.17
-	}
-}
-
-"GJ 3522 Aa:Giclas 41-14 Aa"
-{
-	OrbitBarycenter "Giclas 41-14 A"
-	SpectralType "M3.5V"
-	Radius 225000 # approx. for class
-	AppMag 11.94
-
-	EllipticalOrbit {
-		Period          0.021	# 7.6dys
-		SemiMajorAxis   0.0255	# estimated from mass ratio 0.19:0.17
-	}
-}
-
-"GJ 3522 Ab:Giclas 41-14 Ab"
-{
-	OrbitBarycenter "Giclas 41-14 A"
-	SpectralType "M6V" # from estimated mass
-	Radius 105000 # approx. for estimated class
-	AppMag 12.14
-
-	EllipticalOrbit {
-		Period          0.021	# 7.6dys
-		SemiMajorAxis   0.0285	# estimated from mass ratio 0.19:0.17
-		ArgOfPericenter 180
-	}
-}
-
-"GJ 3522 B:Giclas 41-14 B"
-{
-	OrbitBarycenter "Giclas 41-14"
-	SpectralType "M6V" # from mass
-	Radius 105000 # approx. for estimated class
-	AppMag 12.28
-
-	EllipticalOrbit {
-		Period          11.8	# estimate
-		SemiMajorAxis   2.9	# from AB separation and mass ratio (0.19+0.17):0.17
-		ArgOfPericenter 180
-	}
-}
-
-Barycenter 72659 "XI Boo:37 Boo:Gliese 566:ADS 9413"
-{
-	RA 222.847018
-	Dec 19.100634
-	Distance 22.102
-}
-
-"XI Boo A:37 Boo A:Gliese 566 A:ADS 9413 A"
-{
-	OrbitBarycenter "XI Boo"
-	SpectralType "G7V"
-	AppMag 4.67
-
-	EllipticalOrbit {
-		Period          151.6
-		SemiMajorAxis    13.93 # mass ratio 0.94:0.67
-		Eccentricity      0.51
-		Inclination      83.21
-		AscendingNode   270.13
-		ArgOfPericenter 158.75
-		MeanAnomaly     215.38
-	}
-}
-
-"XI Boo B:37 Boo B:Gliese 566 B:ADS 9413 B"
-{
-	OrbitBarycenter "XI Boo"
-	SpectralType "K4V"
-	AppMag 6.94
-
-	EllipticalOrbit {
-		Period          151.6
-		SemiMajorAxis    19.55 # mass ratio 0.94:0.67
-		Eccentricity      0.51
-		Inclination      83.21
-		AscendingNode   270.13
-		ArgOfPericenter 338.75
-		MeanAnomaly     215.38
-	}
-}
-
-53020 # Wolf 358
-{
-	RA 162.718892
-	Dec 6.810118
-	Distance 22.165
-	SpectralType "M4.0V"
-	Radius 180000 # approx. for class
-	AppMag 11.65
-}
-
 113296 # Ross 671
 {
-	RA 344.147643
-	Dec 16.554122
-	Distance 22.284
-	SpectralType "M1.5V"
+	RA 344.14501970
+	Dec 16.55343159
+	Distance 22.3992 # 145.6107 +/- 0.0388 mas
+	SpectralType "M1.5Ve"
 	Radius 324000 # approx. for class
-	AppMag 8.65
+	AppMag 8.638
+}
+
+# Used parallax of component B, from Gaia DR2
+# Winters et al. (2019), eprint arXiv 1906.10147
+# "Three Red Suns in the Sky: A Transiting, Terrestrial Planet in a Triple 
+# M Dwarf System at 6.9 Parsecs"
+# https://arxiv.org/abs/1906.10147
+Barycenter 14101 "LTT 1445"
+{
+	RA 45.46325875 # mass ratio 0.257:(0.215:0.161)
+	Dec -16.59253611
+	Distance 22.4090
+}
+
+1006945865 "LTT 1445 A:GJ 3193:LP 771-96:Luyten 730-18:RECONS 4"
+{
+	RA 45.46412500
+	Dec -16.5933611
+	Distance 22.4090
+	AppMag 11.22
+	SpectralType "M3V"
+	Radius 186400
+}
+
+Barycenter "LTT 1445 BC:GJ 3192:LP 771-95"
+{
+	RA 45.462666667
+	Dec -16.59197222
+	Distance 22.4090
+}
+
+"LTT 1445 B:GJ 3192 A:LP 771-95 A"
+{
+	OrbitBarycenter "LTT 1445 BC"
+	SpectralType "M4V" # estimate from mass and radius
+	AppMag 11.78
+	Radius 164200
+
+	EllipticalOrbit {
+		Period          36.2
+		SemiMajorAxis   3.4096 # mass ratio 0.215:0.161
+		Eccentricity    0.50
+		Inclination     70.41
+		AscendingNode   204.85
+		ArgOfPericenter 333.35
+		MeanAnomaly     169.06
+	}
+}
+
+"LTT 1445 C:GJ 3192 B:LP 771-95 B"
+{
+	OrbitBarycenter "LTT 1445 BC"
+	SpectralType "M4V" # estimate from mass and radius
+	AppMag 12.64
+	Radius 137100
+
+	EllipticalOrbit {
+		Period          36.2
+		SemiMajorAxis   4.5532 # mass ratio 0.215:0.161
+		Eccentricity    0.50
+		Inclination     70.41
+		AscendingNode   204.85
+		ArgOfPericenter 153.35
+		MeanAnomaly     169.06
+	}
 }
 
 "Gliese 299:Ross 619"
 {
-	RA 122.989583
-	Dec 8.774444
-	Distance 22.294
-	SpectralType "M4.0V"
-	Radius 180000 # approx. for class
-	AppMag 12.82
+	RA 122.98983156
+	Dec 8.77305088
+	Distance 22.4200 # 145.4757 +/- 0.5695 mas
+	SpectralType "M4.5V"
+	Radius 160000 # approx. for class
+	AppMag 12.834
 }
 
+# parameters from Martin et al. (2018)
+"WISE 1405+5534:WISE J140518.39+553421.3"
+{
+	RA 211.322480
+	Dec 55.572793
+	Distance 22.59 # 144.35 +/- 8.60 mas
+	Texture "exo-class4night.*"
+	SpectralType "Y0V"
+	Temperature 400 # guess
+	Radius 60000 # approx.
+	AbsMag 50 # extremely low
+}
+
+53020 # Wolf 358
+{
+	RA 162.71679684
+	Dec 6.80812877
+	Distance 22.7291 # 143.4971 +/- 0.0626 mas
+	SpectralType "M4V"
+	Radius 180000 # approx. for class
+	AppMag 11.675
+}
+
+Modify 51317 # Gliese 393
+{
+	Radius 305000 # approx. for class
+}
+
+"2MASS 2146+3813:2MASS J21462206+3813047"
+{
+	RA 326.59196805
+	Dec 38.21804860
+	Distance 22.9603 # 142.0522 +/- 0.0513 mas
+	SpectralType "M5V"
+	Radius 140000 # approx. for class
+	AppMag 12.210
+}
+
+Modify 103096 # Gliese 809
+{
+	Radius 341000 # approx. for class
+}
+
+"GJ 3877:LP 914-54"
+{
+	RA 224.15943498
+	Dec -28.16350623
+	Distance 23.0196 # 141.6865 +/- 0.1063 mas
+	SpectralType "M7.0V"
+	Radius 84000 # approx. for class
+	AppMag 17.141
+}
+
+"GJ 1068:Luyten 230-188"
+{
+	RA 62.61718071
+	Dec -53.60226063
+	Distance 23.2047 # 140.5559 +/- 0.0354 mas
+	SpectralType "M4.5V"
+	Radius 160000 # approx. for class
+	AppMag 13.58
+}
+
+"GJ 1286"
+{
+	RA 353.79359235
+	Dec -2.38905966
+	Distance 23.4122 # 139.3100 +/- 0.1066 mas
+	SpectralType "M5.0V"
+	Radius 140000 # approx. for class
+	AppMag 14.69
+}
+
+# parameters from Martin et al. (2018)
+"WISE 0825+2805:WISE J082507.35+280548.5"
+{
+	RA 126.280554
+	Dec 28.096545
+	Distance 23.461 # 139.02 Â± 4.33 mas
+	Texture "exo-class4night.*"
+	SpectralType "Y0.5V"
+	Radius 60000 # approx.
+	AbsMag 50 # extremely low
+}
+
+# low-quality parallax from Theissen, C. A. (2018), ApJ 862 (2), 173
+# "Parallaxes of Cool Objects with WISE: Filling in for Gaia"
+# http://iopscience.iop.org/article/10.3847/1538-4357/aaccfa/meta
+"WISE 0254+0223:WISE J025409.51+022358.6"
+{
+	RA 43.5328583
+	Dec 2.3989861
+	Distance 23.5 # 139 +/- 40 mas
+	Texture "exo-class4night.*"
+	SpectralType "T8V"
+	Temperature 500 # approx.
+	Radius 60000 # approx.
+	AbsMag 50 # extremely low
+}
+
+"V488 Hya:2MASS J08354256-0819237"
+{
+	RA 353.79359235
+	Dec -2.38905967
+	Distance 23.5305 # 138.6098 +/- 0.2781 mas
+	SpectralType "L6.5V"
+	AbsMag 21.5 # for approximate radius in Celestia
+}
+
+# Distance from average of distances from Gaia DR2 parallax for A and B
+Barycenter "Gliese 105" # orbit of (AB) and C unknown
+{
+	RA 39.027432618 # mass ratio ((0.81:0.08):0.17):0.21
+	Dec 6.884370406 # A: 138.2084 +/- 0.1436 mas
+	Distance 23.577 # B: 138.4637 +/- 0.0886 mas
+}
+
+Barycenter 12114 "Gliese 105 A-B"
+{
+	RA 39.020265166 # mass ratio (0.81:0.08):0.17
+	Dec 6.886891351
+	Distance 23.599 # 138.2084 +/- 0.1436 mas
+}
+
+Barycenter "Gliese 105 A"
+{
+	OrbitBarycenter "Gliese 105"
+
+	EllipticalOrbit {
+		Period            201
+		SemiMajorAxis     6.1 # mass ratio (0.81:0.08):0.17
+		Eccentricity      0.4
+		Inclination     132.2
+		AscendingNode     6.4
+		ArgOfPericenter 277.2
+		MeanAnomaly     351.0
+	}
+}
+
+"Gliese 105 Aa"
+{
+	OrbitBarycenter "Gliese 105 A"
+	SpectralType "K3V"
+	AppMag 5.81
+
+	EllipticalOrbit {
+		Period           61
+		SemiMajorAxis  0.11 # mass ratio 0.81:0.08
+		Eccentricity   0.67
+		Inclination      61
+		AscendingNode   356
+		ArgOfPericenter 174
+		MeanAnomaly     354
+	}
+}
+
+"Gliese 105 Ab"
+{
+	OrbitBarycenter "Gliese 105 A"
+	SpectralType "M7.5V"
+	AppMag 16.90
+
+	EllipticalOrbit {
+		Period           61
+		SemiMajorAxis  1.13 # mass ratio 0.81:0.08
+		Eccentricity   0.67
+		Inclination      61
+		AscendingNode   356
+		ArgOfPericenter 354
+		MeanAnomaly     354
+	}
+}
+
+# Spectral type from same source as orbit; mass and magnitude estimated
+# from spectral type
+"Gliese 105 B"
+{
+	OrbitBarycenter "Gliese 105"
+	SpectralType "M4.5V"
+	AbsMag 12.6 # guess from spectral type
+
+	EllipticalOrbit {
+		Period           201
+		SemiMajorAxis   32.2 # mass ratio (0.81:0.08):0.17
+		Eccentricity     0.4
+		Inclination    132.2
+		AscendingNode    6.4
+		ArgOfPericenter 97.2
+		MeanAnomaly    351.0
+	}
+}
+
+"BX Cet:Gliese 105 C" # SIMBAD calls it GJ 105 B
+{
+	RA 39.06361119
+	Dec 6.87164564
+	Distance 23.555 # parallax: 138.4637 +/- 0.0886 mas
+	AppMag 11.664
+	SpectralType "M3.5V"
+	Radius 225000 # approx. for class
+}
+
+# parameters from Martin et al. (2018)
+# BT-Settl model parameters from Beichman et al. (2014), ApJ 783 (2), 68
+# "WISE Y Dwarfs as Probes of the Brown Dwarf-Exoplanet Connection"
+# https://iopscience.iop.org/article/10.1088/0004-637X/783/2/68/meta
+"WISE 2056+1459:WISE J205628.91+145953.2"
+{
+	RA 314.120498
+	Dec 14.998118
+	Distance 23.580 # 138.32 +/- 3.86 mas
+	Texture "exo-class4night.*"
+	SpectralType "Y0V"
+	Temperature 407
+	Radius 65000
+	AbsMag 50 # extremely low
+}
+
+"GJ 4274:Luyten 788-34"
+{
+	RA 335.77915456
+	Dec -17.60731501
+	Distance 23.6040 # 138.1782 +/- 0.2484 mas
+	SpectralType "M4.5Ve"
+	Radius 160000 # approx. for class
+	AppMag 13.30
+}
+
+# Used parallax of component C from Gaia DR2
 Barycenter "Gliese 667:CD-34 11626" # orbit of (AB) & C unknown
 {
-	RA  259.735861  # mass ratio (0.68+0.59):0.35
-	Dec -34.990567  #
-	Distance 22.296
+	RA 259.7396833   # mass ratio (0.68:0.59):0.35
+	Dec -34.99129014
+	Distance 23.6316
 }
 
 Barycenter 84709 "Gliese 667 AB:CD-34 11626 AB"
 {
-	RA  259.734835
-	Dec -34.989574
-	Distance 22.296
+	RA  259.7381868
+	Dec -34.9897615
+	Distance 23.6316 # 138.0171 +/- 0.0918 mas
 }
 
 "Gliese 667 A:CD-34 11626 A"
@@ -2563,7 +3082,7 @@ Barycenter 84709 "Gliese 667 AB:CD-34 11626 AB"
 
 	EllipticalOrbit {
 		Period           42.15
-		SemiMajorAxis     5.75 # mass ratio 0.68:0.59
+		SemiMajorAxis     5.98 # mass ratio 0.68:0.59
 		Eccentricity      0.58
 		Inclination     136.65
 		AscendingNode   305.37
@@ -2580,7 +3099,7 @@ Barycenter 84709 "Gliese 667 AB:CD-34 11626 AB"
 
 	EllipticalOrbit {
 		Period           42.15
-		SemiMajorAxis     6.62 # mass ratio 0.68:0.59
+		SemiMajorAxis     7.13 # mass ratio 0.68:0.59
 		Eccentricity      0.58
 		Inclination     136.65
 		AscendingNode   305.37
@@ -2591,308 +3110,56 @@ Barycenter 84709 "Gliese 667 AB:CD-34 11626 AB"
 
 "Gliese 667 C:CD-34 11626 C"
 {
-	RA 259.739583
-	Dec -34.994167
-	Distance 22.296
+	RA 259.74511327
+	Dec -34.99683693
+	Distance 23.6316
 	SpectralType "M1.5V"
 	Radius 324000 # approx. for class
-	AppMag 10.26
+	AppMag 10.22
 }
 
-14101 "GJ 3192:LP 771-95 A:Luyten 730-18:RECONS 4"
+"WISE 0607+2429:WISE 0607+2429:WISEP J060738.65+242953.4"
 {
-	RA 45.46411209
-	Dec -16.593372777
-	Distance 22.680
-	SpectralType "M2.5V"
-	Radius 290000 # approx. for class
-	AppMag 11.22
+	RA 91.91259273
+	Dec 24.49911608
+	Distance 23.8166 # 136.9449 +/- 0.6553 mas
+	SpectralType "L9V"
+	AbsMag 23 # approx. for radius in Celestia
 }
 
-"GJ 3193:LP 771-95 B:LP 771-96"
+# parameters from Martin et al. (2018)
+# BT-Settl model parameters from Beichman et al. (2014), ApJ 783 (2), 68
+# "WISE Y Dwarfs as Probes of the Brown Dwarf-Exoplanet Connection"
+# https://iopscience.iop.org/article/10.1088/0004-637X/783/2/68/meta
+"WISE 1738+2732:WISE J173835.53+273259.0"
 {
-	RA 45.46547306
-	Dec -16.59479288
-	Distance 22.680
-	SpectralType "M3.5V"
-	Radius 225000 # approx. for class
-	AppMag 11.79
+	RA 264.648060
+	Dec 27.549749
+	Distance 23.936 # 136.26 +/- 4.27 mas
+	Texture "exo-class4night.*"
+	SpectralType "Y0V"
+	Temperature 409
+	Radius 64300
+	AbsMag 50 # extremely low
 }
 
-"LP 771-95 C"
-{
-	RA 45.46432292
-	Dec -16.59359277
-	Distance 22.680
-	SpectralType "M5V"
-	Radius 140000 # approx. for class
-	AppMag 12.65
-}
-
-# =============================================================
-# Additional stars between end of RECONS Top 100 and 25 ly: 
-# Non-Hipparcos and Hip stars with additional definitions
-
-# Jao et al. (2005) The Solar Neighborhood XIII: Parallax Results 
-# from the CTIOPI 0.9-m Program -- Stars with mu >= 1"/year 
-# (MOTION Sample)
-# http://arxiv.org/abs/astro-ph/0502167
-"GJ 1068:Luyten 230-188"
-{
-	RA 62.617083
-	Dec -53.602222
-	Distance 22.742
-	SpectralType "M4.5V"
-	Radius 160000 # approx. for class
-	AppMag 13.62
-}
-
-# Bergfors et al. (2010) Lucky Imaging survey for southern M 
-# dwarf binaries
-# http://arxiv.org/abs/1006.2377
-Barycenter "LP 993-115 A:Luyten 369-44:2MASS J02451431-4344102" # orbit of Aa&Ab unknown, mass ratio ~1:1
-{
-	RA 41.309583
-	Dec -43.736111
-	Distance 22.8
-}
-
-"LP 993-115 Aa:Luyten 369-44 A:2MASS J02451431-4344102 A"
-{
-	RA 41.309583
-	Dec -43.7361467 # separation 1.8AU
-	Distance 22.8
-	SpectralType "M4.0V"
-	Radius 180000 # approx. for class
-	AppMag 12.67
-}
-
-"LP 993-115 Ab:Luyten 369-44 B:2MASS J02451431-4344102 B"
-{
-	RA 41.309583
-	Dec -43.7360753 # separation 1.8AU
-	Distance 22.8
-	SpectralType "M4.5V"
-	Radius 160000 # approx. for class
-	AppMag 12.7 # estimate
-}
-
-Barycenter "LP 993-115" # orbit of AB unknown, mass ratio ~2:1
-{
-	RA 41.304583
-	Dec -43.738148
-	Distance 22.8
-}
-
-"LP 993-115 B:2MASS J02451070-4344319"
-{
-	RA 41.294583
-	Dec -43.742222
-	Distance 22.8
-	SpectralType "M5V"
-	Radius 140000 # approx. for class
-	AppMag 12.2
-}
-
-Modify 103096 # Gliese 809
-{
-	Radius 305000 # approx. for class
-}
-
-Modify 51317 # Gliese 393
-{
-	Radius 305000 # approx. for class
-}
-
-"Gliese 293:Luyten 97-12"
-{
-	RA 118.311250
-	Dec -67.791944
-	Distance 23.099
-	SpectralType "DQ9"
-	AppMag 14.08
-}
-
-# Shkolnik, Liu & Reid (2009) Identifying the Young Low-mass 
-# Stars within 25 pc. I. Spectroscopic Observations.
-# http://arxiv.org/abs/0904.3323
-"Giclas 227-22:LP 71-82"
-{
-	RA 270.569167
-	Dec 4.262500
-	Distance 23.2
-	SpectralType "M6.1V"
-	Radius 105000 # approx. for class
-	AppMag 13.51
-}
-
-Barycenter 12114 "Gliese 105" # orbit of A & B unknown
-{
-	RA 39.023977    # mass ratio (0.81+0.08):0.21
-	Dec 6.880494    #
-	Distance 23.420
-}
-
-Barycenter "Gliese 105 A"
-{
-	RA 39.015969
-	Dec 6.883364
-	Distance 23.420
-}
-
-"Gliese 105 Aa"
-{
-	OrbitBarycenter "Gliese 105 A"
-	SpectralType "K3V"
-	AppMag 5.81
-
-	EllipticalOrbit {
-		Period          61
-		SemiMajorAxis   1.3    # mass ratio 0.81:0.08
-		Eccentricity    0.67
-		Inclination	61
-		AscendingNode   356
-		ArgOfPericenter 354
-		MeanAnomaly     354
-	}
-}
-
-"Gliese 105 Ab"
-{
-	OrbitBarycenter "Gliese 105 A"
-	SpectralType "M7.5V"
-	Radius 80000 # approx. for class
-	AppMag 16.90
-
-	EllipticalOrbit {
-		Period          61
-		SemiMajorAxis   13.6   # mass ratio 0.81:0.08
-		Eccentricity    0.67
-		Inclination	61
-		AscendingNode   356
-		ArgOfPericenter 174
-		MeanAnomaly     354
-	}
-}
-
-"BX Cet:Gliese 105 B"
-{
-	RA 39.057917
-	Dec 6.868333
-	Distance 23.420
-	SpectralType "M3.5V"
-	Radius 225000 # approx. for class
-	AppMag 11.66
-}
-
-"GJ 1286"
-{
-	RA 353.794583
-	Dec -2.390278
-	Distance 23.584
-	SpectralType "M5.5V"
-	Radius 122000 # approx. for class
-	AppMag 14.67
-}
-
-1016993109 "GJ 4063:LP 229-17"
-{
-	RA 278.652500
-	Dec 40.123889
-	Distance 23.635
-	SpectralType "M3.5V"
-	Radius 225000 # approx. for class
-	AppMag 11.75
-}
-
-"GJ 4053:LP 71-165"
-{
-	RA 274.740417
-	Dec 66.192222
-	Distance 23.721
-	SpectralType "M4.5V"
-	Radius 160000 # approx. for class
-	AppMag 13.49
-}
-
-# Henry et al. (2006) The solar neighborhood XVII parallax 
-# results from the CTIOPI 0.9 m program: 20 new members of the 
-# RECONS 10 parsec sample. AJ, 132, 2360-71.
-# http://iopscience.iop.org/1538-3881/132/6/2360/pdf/1538-3881_132_6_2360.pdf
-Barycenter 5496 "Gliese 54:Luyten 87-59"
-{
-	RA 17.595417
-	Dec -67.445000
-	Distance 23.874
-}
-
-# Goldin & Makarov (2007) Astrometric orbits for Hipparcos 
-# stochastic binaries. AJ Supplement Series, 173, 137-42.
-# http://iopscience.iop.org/0067-0049/173/1/137/fulltext/71924.text.html
-"Gliese 54 A:Luyten 87-59 A"
-{
-	OrbitBarycenter "Gliese 54"
-	SpectralType "M2.0V"
-	Radius 305000 # approx. for class
-	AppMag 10.17	# sum 9.82, diff 1.04
-		
-	EllipticalOrbit {		
-		Period		1.169
-		SemiMajorAxis	0.40 # mass ratio 0.83
-		Eccentricity  	0.41
-		Inclination  	94
-		AscendingNode  	92
-  		ArgOfPericenter 	123
-	}
-}
-
-"Gliese 54 B:Luyten 87-59 B"
-{
-	OrbitBarycenter "Gliese 54"
-	SpectralType "M3.0V"
-	Radius 270000 # approx. for class
-	AppMag 11.21		# sum 9.82, diff 1.04
-		
-	EllipticalOrbit {		
-		Period		1.169
-		SemiMajorAxis	0.48 # mass ratio 0.83
-		Eccentricity  	0.41
-		Inclination  	94
-		AscendingNode  	92
-  		ArgOfPericenter 	303
-	}
-}
-
-# Dahn, C.C. et al. (2002) "Astrometry and photometry
-# for cool dwarfs and brown dwarfs." AJ, 124, 1170
-# (http://www.iop.org/EJ/abstract/-link=10023955/1538-3881/124/2/1170)
 "2MASS 1507-1627:2MASS J15074769-1627386"
 {
-	RA 226.948709
-	Dec -16.460722
-	Distance 23.912
+	RA 226.94864865
+	Dec -16.46114400
+	Distance 24.1180 # 135.2332 +/- 0.3274 mas
 	SpectralType "L5V"
 	AbsMag 21 # for approximate radius in Celestia
 }
 
-"GJ 4274:Luyten 788-34"
-{
-	RA 335.777500
-	Dec -17.606944
-	Distance 24.268
-	SpectralType "M4.5V"
-	Radius 160000 # approx. for class
-	AppMag 13.26
-}
-
-# Delfosse, X. et al. (1999) "New Neighbours I: 13 new
-# companions to nearby M dwarfs" A&A, 344, 897
-# (http://arxiv.org/abs/astro-ph/9812008)
+# Delfosse et al. (1999), A&A 344, 897
+# "New neighbours. I. 13 new companions to nearby M dwarfs"
+# http://adsabs.harvard.edu/abs/1999A&A...344..897D
 Barycenter 83945 "GJ 3991:Giclas 203-47"
 {
-	RA 257.380309
-	Dec 43.682026
-	Distance 24.284
+	RA 257.38142860
+	Dec 43.68131523
+	Distance 24.2320 # 134.5971 +/- 0.4894 mas
 }
 
 "GJ 3991 A:Giclas 203-47 A"
@@ -2903,7 +3170,7 @@ Barycenter 83945 "GJ 3991:Giclas 203-47"
 	AppMag 11.80
 
 	EllipticalOrbit {
-		Period          0.04	# 15 days
+		Period          0.04	# 15 d
 		SemiMajorAxis   0.6	# estimated from mass ratio 0.3:0.5
 		Eccentricity    0.07
 		ArgOfPericenter 180
@@ -2912,55 +3179,60 @@ Barycenter 83945 "GJ 3991:Giclas 203-47"
 
 "GJ 3991 B:Giclas 203-47 B"
 {
-
 	OrbitBarycenter "Giclas 203-47"
 	SpectralType "D"
 	AbsMag 13.7 # for a 0.5-solar-mass white dwarf
 
 	EllipticalOrbit {
-		Period          0.04	# 15 days
+		Period          0.04	# 15 d
 		SemiMajorAxis   0.4	# estimated from mass ratio 0.3:0.5
 		Eccentricity    0.07
 	}
 }
 
-# Henry et al. (2006) The solar neighborhood XVII parallax 
-# results from the CTIOPI 0.9 m program: 20 new members of the 
-# RECONS 10 parsec sample. AJ, 132, 2360-71.
+3765 # HD 4628
+{
+	RA 12.09573477
+	Dec 5.28061376
+	Distance 24.2497 # 134.4990 +/- 0.0890 mas
+	SpectralType "K2.5V"
+	AppMag 5.74
+}
+
+# apparent magnitude from Henry et al. (2006) AJ 132 (6), 2360
+# "The Solar Neighborhood. XVII. Parallax Results from the CTIOPI 0.9 m Program:
+# 20 New Members of the RECONS 10 Parsec Sample"
 # http://iopscience.iop.org/1538-3881/132/6/2360/pdf/1538-3881_132_6_2360.pdf
-"GJ 4248:LHS 3746:Luyten 499-46" {
-	RA 330.622500
-	Dec -37.080833
-	Distance 24.288
+"GJ 4248:LHS 3746:Luyten 499-46"
+{
+	RA 330.6223980
+	Dec -37.0809310
+	Distance 24.287 # 134.29 +/- 1.31 mas
 	SpectralType "M3.0V"
 	Radius 270000 # approx. for class
-	AppMag 11.80
+	AppMag 11.76
 }
 
-Modify 12781 # Gliese 109
+Modify 106255 # Wolf 922
 {
-	Radius 225000 # approx. for class
-}
-
-
-"GJ 1224"
-{
-	RA 271.887083
-	Dec -15.964167
-	Distance 24.598
-	SpectralType "M4.5V"
 	Radius 160000 # approx. for class
-	AppMag 13.61
 }
 
-# Drummond JD, Christou JC, Fugate RQ. Full adaptive optics images of
-# ADS 9731 and mu Cassiopeiae: Orbits and masses. ApJ 1995; 450: 380-91
-# http://cdsads.u-strasbg.fr//full/1995ApJ...450..380D/0000380.000.html
+2021 # Bet Hyi
+{
+	RA 6.43779316
+	Dec -77.25424612
+	Distance 24.327 # 134.07 +/- 0.11 mas
+	SpectralType "G0V"
+	AppMag 2.79
+}
+
+# Masses from same source as orbit
 Barycenter 5336 "MU Cas:30 Cas:Gliese 53"
 {
-	RA 17.053838
-	Dec 54.924228
-	Distance 24.638
+	RA 17.06831127
+	Dec 54.92034067
+	Distance 24.638 # 132.38 +/- 0.82 mas
 }
 
 "MU Cas A:30 Cas A:Gliese 53 A"
@@ -2969,11 +3241,11 @@ Barycenter 5336 "MU Cas:30 Cas:Gliese 53"
 	SpectralType "G5VI"
 	AppMag 5.17
 
-	EllipticalOrbit {		# fully specified orientation
-		Period          21.753
-		SemiMajorAxis   1.437   # mass ratio 0.742:0.173
+	EllipticalOrbit {	      # fully specified orientation
+		Period         21.753
+		SemiMajorAxis   1.437 # mass ratio 0.742:0.173
 		Eccentricity    0.561
-		Inclination	28.0
+		Inclination	 28.0
 		AscendingNode   334.7
 		ArgOfPericenter 135.0
 		MeanAnomaly     41.52
@@ -2986,25 +3258,43 @@ Barycenter 5336 "MU Cas:30 Cas:Gliese 53"
 	SpectralType "MVI"
 	AppMag 11.00
 
-	EllipticalOrbit {		# fully specified orientation
-		Period          21.753
-		SemiMajorAxis   6.165   # mass ratio 0.742:0.173
+	EllipticalOrbit {	      # fully specified orientation
+		Period         21.753
+		SemiMajorAxis   6.165 # mass ratio 0.742:0.173
 		Eccentricity    0.561
-		Inclination	28.0
+		Inclination	 28.0
 		AscendingNode   334.7
 		ArgOfPericenter 315.0
 		MeanAnomaly     41.52
 	}
 }
 
-"GJ 3378:Luyten 1813-21"
+7981 # 107 Psc
 {
-	RA 90.290417
-	Dec 59.598333
-	Distance 24.691
-	SpectralType "M3.5V"
-	Radius 225000 # approx. for class
-	AppMag 11.71
+	RA 25.62401456
+	Dec 20.26851674
+	Distance 24.8046 # 131.4903 +/- 0.1515 mas
+	SpectralType "K1V"
+	AppMag 5.24
+}
+
+Modify 113368 # Fomalhaut 
+{
+	UniformRotation
+	{
+		Inclination    81.8    # rotation pole matches debris disk
+		AscendingNode  176.6   # Bouquin et al. (2009) A&A 498, L41-44
+		# (http://www.aanda.org/index.php?option=article&access=doi&doi=10.1051/0004-6361/200911854)
+ 	}
+}
+
+113283 # TW PsA (Fomalhaut B)
+{
+	RA 344.10022206
+	Dec -31.56556530
+	Distance 24.8144 # 131.4380 +/- 0.0856 mas
+	SpectralType "K4Ve"
+	AppMag 6.48
 }
 
 Modify 65859 # Ross 490
@@ -3012,202 +3302,81 @@ Modify 65859 # Ross 490
 	Radius 341000 # approx. for class
 }
 
-Modify 91262 # Vega 
+"G 141-36"
 {
-	SemiAxes [ 1 0.81 1 ] # equatorial radius 23% greater than polar
+	RA 282.07307098
+	Dec -7.68921596
+	Distance 24.8596 # 131.1990 +/- 0.0788 mas
+	SpectralType "M5.0V"
+	Radius 140000 # approx. for class
+	AppMag 14.248
+}
+
+"GJ 4053:LP 71-165"
+{
+	RA 274.73846839
+	Dec 66.19258373
+	Distance 24.9408 # 130.7722 +/- 0.0443 mas
+	SpectralType "M4.5V"
+	Radius 160000 # approx. for class
+	AppMag 13.406
+}
+
+"Fomalhaut C:ALF PsA C:LP 876-10"
+{
+	RA 342.01871887
+	Dec -24.36881191
+	Distance 25.0305 # 130.3032 +/- 0.0746 mas
+	SpectralType "M4.0Ve"
+	Radius 160000 # approx. for class
+	AppMag 12.624
+}
+
+Modify 91262 # Vega
+{
+	SemiAxes [ 1 0.80 1 ] # equatorial radius 25% greater than polar
 
 	UniformRotation
 	{
 	    Period         12.4
-	    Inclination    28   # rotation pole points
-	    AscendingNode  15   # towards solar system
+	    # Inclination    28   # rotation pole points
+	    # AscendingNode  15   # towards solar system
+	    Inclination   147.35 # inclination (i) = 4.54
+	    AscendingNode 192.95 # inclination (i) = 8.6
 	}
 }
 
-# Kirpatrick et al. (2011) The First Hundred Brown Dwarfs 
-# Discovered by the Wide-field Infrared Survey Explorer (WISE)
-# http://arxiv.org/abs/1108.4677
-"WISE 2056+1459:WISE J2046+1459:WISEPC J205628.90+145953.3"
+Modify 12781 # Gliese 109
 {
-	Texture "exo-class4night.*"
-	RA 314.120417
-	Dec 14.998056
-	Distance 25.1
-	SpectralType "T9.5" # actually Y0
-	Temperature 350
-	Radius 70000
-	AbsMag 50 # extremely low
-}
-
-Modify 113368 # Fomalhaut 
-{
-	UniformRotation
-	{
-	    Inclination    81.8    # rotation pole matches debris disk
-	    AscendingNode  176.6   # Bouquin et al. (2009) A&A 498, L41-44
-# (http://www.aanda.org/index.php?option=article&access=doi&doi=10.1051/0004-6361/200911854)
- 	}
-}
-
-# Seifahrt, A et al. Improved orbital solution and masses for the 
-# very low-mass multiple system LHS 1070. A&A 2008; 484: 429-34
-# http://arxiv.org/pdf/0803.0628v2.pdf
-Barycenter "GJ 2005:LHS 1070"
-{
-	RA 6.184167
-	Dec -27.140000
-	Distance 25.186
-}
-
-"GJ 2005 A:LHS 1070 A"
-{
-	OrbitBarycenter "GJ 2005"
-	SpectralType "M5.5V"
-	Radius 122000 # approx. for class
-	AppMag 15.61
-
-	EllipticalOrbit {
-		Period           82
-		SemiMajorAxis    7.0	# mass ratio 0.157:0.115	
-		Eccentricity     0.01
-		Inclination      44
-		AscendingNode    342
-		ArgOfPericenter  45
-		MeanAnomaly      10 # approx.
-	}
-}
-
-Barycenter "GJ 2005 BC:LHS 1070 BC"
-{
-	OrbitBarycenter "GJ 2005"
-
-	EllipticalOrbit {
-		Period           82
-		SemiMajorAxis    5.2	# mass ratio 0.157:0.115
-		Eccentricity     0.01
-		Inclination      44
-		AscendingNode    342
-		ArgOfPericenter  225
-		MeanAnomaly      10 # approx.
-	}
-}
-
-"GJ 2005 B:LHS 1070 B"
-{
-	OrbitBarycenter "GJ 2005 BC"
-	SpectralType "M8.5V"
-	Radius 66000 # approx. for class
-	AppMag 18.07
-
-	EllipticalOrbit {
-		Period           17.015031	# period 6214.74 dy
-		SemiMajorAxis    1.78		# mass ratio ~1:1
-		Eccentricity     0.034
-		Inclination      43.34
-		AscendingNode    341.84
-		ArgOfPericenter  138.79
-		MeanAnomaly      187.55
-	}
-}
-
-"GJ 2005 C:LHS 1070 C"
-{
-	OrbitBarycenter "GJ 2005 BC"
-	SpectralType "M9.2V"
-	Radius 56000 # approx. for class
-	AppMag 18.89
-
-	EllipticalOrbit {
-		Period           17.015031	# period 6214.74 dy
-		SemiMajorAxis    1.79		# mass ratio ~1:1
-		Eccentricity     0.034
-		Inclination      43.34
-		AscendingNode    341.84
-		ArgOfPericenter  318.79
-		MeanAnomaly      187.55
-	}
-}
-
-"Gliese 102:Luyten 1305-10"
-{
-	RA 38.405000
-	Dec 24.927500
-	Distance 25.284
-	SpectralType "M4V"
-	Radius 180000 # approx. for class
-	AppMag 12.96
-}
-
-Modify 88574 # Luyten 991-14
-{
-	Radius 305000 # approx. for class
-}
-
-"GJ 1093:LHS 223"
-{
-	RA 104.869583
-	Dec 19.349444
-	Distance 25.323
-	SpectralType "M5.0V"
-	Radius 140000 # approx. for class
-	AppMag 14.83
-}
-
-Modify 61874 # Gliese 480.1
-{
-	Radius 180000 # approx. for class
-}
-
-# Deacon NR, Hambly NC, Cooke JA. Southern Infrared Proper Motion 
-# Survey I: Discovery of New High Proper Motion Stars From First 
-# Full Hemisphere Scan. 2004.
-# http://arxiv.org/abs/astro-ph/0412127
-# RECONS revised original distance outwards from 11.8ly
-# (http://en.allexperts.com/q/Astronomy-1360/2008/1/SIPS-1259-4336.htm)
-"SIPS 1259-4336:SIPS J1259-4336:2MASS 1259-4336:2MASS J12590470-4336243"
-{
-	RA 194.770000
-	Dec -43.606667
-	Distance 25.40
-	SpectralType "M8.5V"
-	Radius 66000 # approx. for class
-	AbsMag 17.5 # approx.
-}
-
-# Castro & Gizis (2011) Discovery of a Late L Dwarf: 
-# WISEP J060738.65+242953.4
-# http://arxiv.org/abs/1110.4351
-"WISE 0607+2429:WISE 0607+2429:WISEP J060738.65+242953.4"
-{
-	RA 91.910833
-	Dec 24.498056
-	Distance 25.5
-	SpectralType "L8.0V"
-	AbsMag 23 # approx. for radius in Celestia
+	Radius 225000 # approx. for class
 }
 
 #========================================================================
 # Nearby multiple star with poor Hipparcos parallax
 
+# Used Gaia DR2 parallax for B
 Barycenter 55203 "Alula Australis:XI UMa:53 UMa:Gliese 423:ADS 8119"
 {
-	RA 169.54545
-	Dec 31.529134
-	Distance 27.294
+	RA 169.545550
+	Dec 31.529289
+	Distance 28.4885 # 114.4867 +/- 0.4316 mas
 }
 
+# Masses from Fuhrmann et al. (2016), MNRAS 459 (2), 1682
+# "Evidence for very nearby hidden white dwarfs"
+# https://doi.org/10.1093/mnras/stw760
 Barycenter "Alula Australis A:XI UMa A:53 UMa A:Gliese 423 A:ADS 8119 A"
 {
 	OrbitBarycenter "Alula Australis"
 
-	EllipticalOrbit {               # fully specified orientation
-		Period          59.878
-		SemiMajorAxis   9.30    # mass ratio (1.05+0.4):(1.05+0.08)
-		Eccentricity    0.398
-		Inclination	14.09
-		AscendingNode   192.13
-		ArgOfPericenter 9.69
-		MeanAnomaly     29.62
+	EllipticalOrbit {            # fully specified orientation
+		Period         59.88
+		SemiMajorAxis   9.65 # mass ratio (0.98:0.38):(0.88:0.17)
+		Eccentricity    0.40
+		Inclination    14.09
+		AscendingNode 192.13
+		ArgOfPericenter 9.70
+		MeanAnomaly    29.62
 	}
 }
 
@@ -3215,50 +3384,50 @@ Barycenter "Alula Australis B:XI UMa B:53 UMa B:Gliese 423 B:ADS 8119 B"
 {
 	OrbitBarycenter "Alula Australis"
 
-	EllipticalOrbit {               # fully specified orientation
-		Period          59.878
-		SemiMajorAxis   11.93    # mass ratio (1.05+0.4):(1.05+0.08)
-		Eccentricity    0.398
-		Inclination	14.09
+	EllipticalOrbit {              # fully specified orientation
+		Period           59.88
+		SemiMajorAxis    12.50 # mass ratio (0.98:0.38):(0.88:0.17)
+		Eccentricity      0.40
+		Inclination      14.09
 		AscendingNode   192.13
-		ArgOfPericenter 189.69
-		MeanAnomaly     29.62
+		ArgOfPericenter 189.70
+		MeanAnomaly      29.62
 	}
 }
 
-"Alula Australis Aa:XI UMa Aa:53 UMa Aa:Gliese 423 Aa"
+"Alula Australis Aa:XI UMa Aa:53 UMa Aa:Gliese 423 Aa"		
 {
-	OrbitBarycenter "Alula Australis A"
+	OrbitBarycenter "Alula Australis A"	
 	SpectralType "G0V"
 	AppMag 4.33
 
-	EllipticalOrbit {               # fully specified orientation
-		Period          1.832
-		SemiMajorAxis   0.13    # mass ratio 1.05:0.4
-		Eccentricity    0.53
-		Inclination	137.0
-		AscendingNode   298.1
-		ArgOfPericenter 187.9
-		MeanAnomaly     133.8
-	}
+	EllipticalOrbit {             # fully specified orientation
+		Period          1.834
+		SemiMajorAxis    0.13 # mass ratio 0.98:0.38
+		Eccentricity     0.61
+		Inclination     146.3
+		AscendingNode   203.8
+		ArgOfPericenter 285.2
+		MeanAnomaly      73.4
+	}	
 }
 
-"Alula Australis Ab:XI UMa Ab:53 UMa Ab:Gliese 423 Ab"
-{
-	OrbitBarycenter "Alula Australis A"
-	SpectralType "M2V" # from estimated mass of 0.4
-	AbsMag 9.3         # for estimated spectral class
-
-	EllipticalOrbit {               # fully specified orientation
-		Period          1.832
-		SemiMajorAxis   0.35    # mass ratio 1.05:0.4
-		Eccentricity    0.53
-		Inclination	137.0
-		AscendingNode   298.1
-		ArgOfPericenter 7.9
-		MeanAnomaly     133.8
-	}
-}
+"Alula Australis Ab:XI UMa Ab:53 UMa Ab"		
+{		
+	OrbitBarycenter "Alula Australis A"	
+	SpectralType "M2V" # from mass estimate of 0.38
+	AbsMag 10.3 # for estimated spectral class	
+		
+	EllipticalOrbit {             # fully specified orientation
+		Period          1.834
+		SemiMajorAxis    0.34 # mass ratio 0.98:0.38
+		Eccentricity     0.61
+		Inclination     146.3
+		AscendingNode   203.8
+		ArgOfPericenter 105.2
+		MeanAnomaly      73.4
+	}	
+}		
 
 "Alula Australis Ba:XI UMa Ba:53 UMa Ba:Gliese 423 Ba"
 {
@@ -3267,93 +3436,51 @@ Barycenter "Alula Australis B:XI UMa B:53 UMa B:Gliese 423 B:ADS 8119 B"
 	AppMag 4.8
 
 	EllipticalOrbit {
-		Period          0.0109 # 3.98dy
-		SemiMajorAxis   0.004  # mass ratio 1.05:0.08
+		Period          0.0109 # 3.981 d
+		SemiMajorAxis   0.008  # mass ratio 0.88:0.17
 		Eccentricity    0
+		Inclination     102 # plane-of-inclination:
+		AscendingNode   70  # 12.7 deg
 		ArgOfPericenter 180
+	}
+
+	UniformRotation {
+		Inclination     102 # guess, to match orbit
+		AscendingNode   70
 	}
 }
 
 "Alula Australis Bb:XI UMa Bb:53 UMa Bb:Gliese 423 Bb"
+# Fuhrmann et al. (2016) suggest it could be a white dwarf
 {
 	OrbitBarycenter "Alula Australis B"
-	SpectralType "L"  # brown dwarf
-	AbsMag 21         # for approximate radius in Celestia
+	SpectralType "M5V" # estimate from mass
+	AbsMag 16          # for approximate radius in Celestia
 
 	EllipticalOrbit {
-		Period          0.0109 # 3.981dy
-		SemiMajorAxis   0.056  # mass ratio 1.05:0.08
+		Period          0.0109 # 3.981 d
+		SemiMajorAxis   0.056  # mass ratio 0.88:0.17
 		Eccentricity    0
+		Inclination     102 # plane-of-inclination:
+		AscendingNode   70  # 12.7 deg
+	}
+
+	UniformRotation {
+		Inclination     102 # guess, to match orbit
+		AscendingNode   70
 	}
 }
 
-# Washington Multiplicity Catalog
-# (http://ad.usno.navy.mil/wds/wmc/wmc_post191.html)
-"Alula Australis C:XI UMa C:53 UMa C:Gliese 423 C"
+# Gaia DR2 suggests WDS J11182+3132C is an optical pair
+# Wright et al. (2013), A T8.5 Brown Dwarf Member of the xi Ursae Majoris System"
+# https://iopscience.iop.org/1538-3881/145/3/84/
+"Alula Australis C:WISE 1118+3125:WISE J111838.70+312537.9"
 {
-	RA 169.53272
-	Dec 31.539614
-	Distance 27.294
-	SpectralType "M7V"  # from luminosity
-	AppMag 15
+	RA 169.66125400
+	Dec 31.42720000
+	Distance 28.4885
+	SpectralType "T8.5V"
+	Temperature 600 # approx.
+	Radius 60000 # approx.
+	AbsMag 50 # extremely low
 }
-
-#======================================================
-# Delfosse, X. et al. (1999) "New Neighbours I: 13 new
-# companions to nearby M dwarfs" A&A, 344, 897
-# (http://arxiv.org/abs/astro-ph/9812008)
-# RECONS parallax places system well beyond 20ly distance
-# from Hipparcos
-Barycenter "GJ 2130" # orbit of A & B unknown
-{
-	RA 266.556484   # mass ratio 0.3:(0.19+0.15)
-	Dec -32.102873  #
-	Distance 48.536
-}
-
-86961 # GJ 2130 A
-{
-	RA 266.552500
-	Dec -32.103611
-	Distance 48.536
-	SpectralType "M2V"
-	AppMag 10.49
-}
-
-Barycenter 86963 "GJ 2130 B" #true separation of Bab not known
-{
-	RA 266.56015
-	Dec -32.102222
-	Distance 48.536
-}
-
-"GJ 2130 Ba:CD-32 13298 A"
-{
-	RA 266.560000
-	Dec -32.102222
-	Distance 48.536
-	SpectralType "M5.5V" # from apparent magnitude
-	AppMag 11.75
-}
-
-"GJ 2130 Bb:CD-32 13298 B"
-{
-	RA 266.5603
-	Dec -32.102222
-	Distance 48.536
-	SpectralType "M6.5V" # from apparent magnitude
-	AppMag 12.75
-}
-
-#===========================================================
-# Star with erroneously large parallax in Hipparcos
-# (http://simbad.u-strasbg.fr/simbad/sim-id?Ident=hip+85605&NbIdent=1&Radius=2&Radius.unit=arcmin&submit=submit+id)
-85605
-{
-	RA 262.401250
-	Dec 24.653055
-	Distance 180 # from spectral class and ap. mag.
-	SpectralType "K5"
-	AppMag 11.15
-}
-


### PR DESCRIPTION
Updates include:
- Updated distances for most stars, mostly Gaia DR2
- Updated parameters, generally from SIMBAD or individual sources
- New orbital elements for many star systems
The file still retains the overall structure, as well as part of the heading.